### PR TITLE
Use string-based context for queries

### DIFF
--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -49,4 +49,4 @@
         query* (reduce-kv (fn [acc k v] (assoc acc (keyword k) v)) {} query)]
     (log/debug "query - Querying ledger" ledger "-" query*)
     {:status 200
-     :body   (deref! (fluree/query db query*))}))
+     :body   (deref! (fluree/query db (assoc-in query* [:opts :js?] true)))}))


### PR DESCRIPTION
Queries were by default using the CLJ keyword context, even though they were all string-based JSON queries.