### PR TITLE
The one where Wes got carried away changing things in http-api-gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Run `clojure -M -m fluree.http-api.system [profile]` where the optional
 `profile` arg can be one of `prod` (default) or `dev`. See
 `resources/config.edn` for the different parameters these profiles enable.
 
+### Dev
+
+Shortcut for running in dev mode: `clojure -X:run-dev`
+
 ### Docker
 
 You can build a Docker image of this component by running:
@@ -26,3 +30,7 @@ config defaults. They are in all caps and have a `#env` in front of them.
 
 Pull up the root URL of this server in a web browser for Swagger docs of the
 API. I.e. if it says it's running on port 8090, browse to http://localhost:8090/
+
+## Tests
+
+`clojure -X:test` runs the test suite.

--- a/deps.edn
+++ b/deps.edn
@@ -17,4 +17,15 @@
  {:build
   {:deps       {io.github.seancorfield/build-clj
                 {:git/tag "v0.8.5" :git/sha "de693d0"}}
-   :ns-default build}}}
+   :ns-default build}
+
+  :test
+  {:extra-paths ["test"]
+   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.77.1236"}
+                 clj-http/clj-http   {:mvn/version "3.12.3"}}
+   :exec-fn     kaocha.runner/exec-fn
+   :exec-args   {}}
+
+  :run-dev
+  {:exec-fn   fluree.http-api.system/run-server
+   :exec-args {:profile :dev}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/spec-tools             {:mvn/version "0.10.5"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :sha     "4604d2993586ac41c22eac54122b2e062752c8ff"}}
+                                         :sha     "ded19f47734e359ba88fbfb2619c0453bc5aac33"}}
 
  :aliases
  {:build

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -4,12 +4,10 @@
                                           :docker 8090}]}
  :fluree/connection {:method       #or [#env FLUREE_STORAGE_METHOD
                                         #profile {:dev    :file
-                                                  :test   :memory
                                                   :prod   :ipfs
                                                   :docker :file}]
                      :parallelism  #or [#env FLUREE_CONN_PARALLELISM
                                         #profile {:dev    1
-                                                  :test   1
                                                   :prod   4
                                                   :docker 4}]
                      :storage-path #or [#env FLUREE_STORAGE_PATH

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -14,4 +14,10 @@
                                                   :docker 4}]
                      :storage-path #or [#env FLUREE_STORAGE_PATH
                                         #profile {:dev    "data"
-                                                  :docker "data"}]}}
+                                                  :docker "data"}]
+                     :defaults     {:context
+                                    #or [#env FLUREE_DEFAULT_CONTEXT
+                                         #profile {:dev
+                                                   {:id   "@id"
+                                                    :type "@type"
+                                                    :ex   "http://example.com/"}}]}}}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -14,7 +14,4 @@
                                                   :docker 4}]
                      :storage-path #or [#env FLUREE_STORAGE_PATH
                                         #profile {:dev    "data"
-                                                  :docker "data"}]
-                     ;; TODO: What should the default context really be?
-                     :defaults     {:context {:id "@id", :type "@type",
-                                              :ex "http://example.com/"}}}}
+                                                  :docker "data"}]}}

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -193,7 +193,7 @@
                              (exception/create-exception-middleware
                                {::exception/default
                                 (partial exception/wrap-log-to-console
-                                         exception/default-handler)})
+                                         exception/http-response-handler)})
                              muuntaja/format-request-middleware
                              coercion/coerce-response-middleware
                              coercion/coerce-request-middleware]}})

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -32,7 +32,6 @@
 (s/def ::ledger ::non-empty-string)
 (s/def ::txn (s/or :single-map map? :collection-of-maps (s/coll-of map?)))
 (s/def ::context map?)
-(s/def ::defaults (s/keys :opt-un [::context]))
 
 (def server
   #::ds{:start  (fn [{{:keys [handler options]} ::ds/config}]
@@ -161,7 +160,7 @@
          ["/fluree" {:middleware fluree-middleware}
           ["/create"
            {:post {:summary    "Endpoint for creating new ledgers"
-                   :parameters {:body (s/keys :opt-un [::defaults]
+                   :parameters {:body (s/keys :opt-un [::context]
                                               :req-un [::ledger ::txn])}
                    :responses  {201 {:body (s/keys :opt-un [::address ::id]
                                                    :req-un [::alias ::t])}

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -145,18 +145,19 @@
   [{:keys [:fluree/conn :http/middleware :http/routes]}]
   (log/debug "HTTP server running with Fluree connection:" conn
              "- middleware:" middleware "- routes:" routes)
-  (let [default-fdb-middleware [[10 wrap-cors]
-                                [10 (partial wrap-assoc-conn conn)]
-                                [100 wrap-set-fuel-header]]
-        fdb-middleware         (sort-middleware-by-weight
-                                 (concat default-fdb-middleware middleware))]
+  (let [default-fluree-middleware [[10 wrap-cors]
+                                   [10 (partial wrap-assoc-conn conn)]
+                                   [100 wrap-set-fuel-header]]
+        fluree-middleware         (sort-middleware-by-weight
+                                    (concat default-fluree-middleware
+                                            middleware))]
     (ring/ring-handler
       (ring/router
         [["/swagger.json"
           {:get {:no-doc  true
                  :swagger {:info {:title "Fluree HTTP API"}}
                  :handler (swagger/create-swagger-handler)}}]
-         ["/fdb" {:middleware fdb-middleware}
+         ["/fluree" {:middleware fluree-middleware}
           ["/transact"
            {:post {:summary    "Endpoint for submitting transactions"
                    :parameters {:body (s/keys :opt-un [::action ::defaultContext]

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -2,7 +2,8 @@
   (:require
     [fluree.db.json-ld.api :as fluree]
     [fluree.db.util.core :as util]
-    [fluree.db.util.log :as log]))
+    [fluree.db.util.log :as log])
+  (:import (clojure.lang ExceptionInfo)))
 
 (defn deref!
   "Derefs promise p and throws if the result is an exception, returns it otherwise."
@@ -12,55 +13,99 @@
       (throw res)
       res)))
 
-(defn create
-  [{:keys [fluree/conn] {{:keys [ledger txn]} :body} :parameters}]
-  (log/info "Creating ledger" ledger)
-  (let [ledger* (deref! (fluree/create conn ledger))
-        address (:address ledger*)
-        db      (-> ledger*
-                    fluree/db
-                    (fluree/stage txn)
-                    deref!
-                    (->> (fluree/commit! ledger*))
-                    deref!)]
-    {:status 201
-     :body (-> db (select-keys [:alias :t]) (assoc :address address))}))
+(defn error-catching-handler
+  [handler]
+  (fn [req]
+    (try
+      (handler req)
+      (catch ExceptionInfo e
+        (let [msg   (ex-message e)
+              {:keys [status] :as data} (ex-data e)
+              error (dissoc data :status)]
+          (throw (ex-info "Error in ledger handler"
+                          {:response
+                           {:status status
+                            :body   (assoc error :message msg)}}))))
+      (catch Throwable t
+        (throw (ex-info "Error in ledger handler"
+                        {:response {:status 500
+                                    :body   {:error (ex-message t)}}}))))))
 
-(defn transact
-  [{:keys [fluree/conn] {{:keys [ledger txn]} :body} :parameters}]
-  (println "\nTransacting to" ledger ":" (pr-str txn))
-  (let [ledger  (if (deref! (fluree/exists? conn ledger))
-                  (do
-                    (log/debug "transact - Ledger" ledger "exists; loading it")
-                    (deref! (fluree/load conn ledger)))
-                  (throw (ex-info "Ledger does not exist" {:ledger ledger})))
-        address (:address ledger)
-        ;; TODO: Add a transact! fn to f.d.json-ld.api that stages and commits in one step
-        db      (-> ledger
-                    fluree/db
-                    (fluree/stage txn {:context-type :string})
-                    deref!
-                    (->> (fluree/commit! ledger))
-                    deref!)]
-    {:status 200
-     :body   (-> db (select-keys [:alias :t]) (assoc :address address))}))
+(defn txn-body->opts
+  [{:keys [context txn] :as _body}]
+  (let [first-txn (if (map? txn)
+                    txn
+                    (first txn))]
+    (cond-> {}
+            (-> first-txn keys first keyword?) (assoc :context-type :keyword)
+            (-> first-txn keys first string?) (assoc :context-type :string)
+            context (assoc :context context))))
 
-(defn query
-  [{:keys [fluree/conn] {{:keys [ledger query]} :body} :parameters}]
-  (let [db     (->> ledger (fluree/load conn) deref! fluree/db)
-        query* (-> query
-                   (->> (reduce-kv (fn [acc k v] (assoc acc (keyword k) v)) {}))
-                   (assoc-in [:opts :context-type] :string))]
-    (log/debug "query - Querying ledger" ledger "-" query*)
-    {:status 200
-     :body   (deref! (fluree/query db query*))}))
+(defn query-body->opts
+  [{:keys [query] :as _body}]
+  (cond-> {}
+          (-> query keys first keyword?) (assoc :context-type :keyword)
+          (-> query keys first string?) (assoc :context-type :string)))
 
-(defn history
-  [{:keys [fluree/conn] {{:keys [ledger query]} :body} :parameters}]
-  (let [ledger* (->> ledger (fluree/load conn) deref!)
-        query*  (-> query
-                    (->> (reduce-kv (fn [acc k v] (assoc acc (keyword k) v)) {}))
-                    (assoc-in [:opts :context-type] :string))]
-    (log/debug "history - Querying ledger" ledger "-" query*)
-    {:status 200
-     :body   (deref! (fluree/history ledger* query*))}))
+(def create
+  (error-catching-handler
+    (fn [{:keys [fluree/conn] {{:keys [ledger txn] :as body} :body} :parameters}]
+      (log/info "Creating ledger" ledger)
+      (let [opts    (txn-body->opts body)
+            _       (log/debug "create opts:" opts)
+            ledger* (deref! (fluree/create conn ledger opts))
+            address (:address ledger*)
+            db      (-> ledger*
+                        fluree/db
+                        (fluree/stage txn opts)
+                        deref!
+                        (->> (fluree/commit! ledger*))
+                        deref!)]
+        {:status 201
+         :body   (-> db (select-keys [:alias :t]) (assoc :address address))}))))
+
+(def transact
+  (error-catching-handler
+    (fn [{:keys [fluree/conn] {{:keys [ledger txn] :as body} :body} :parameters}]
+      (println "\nTransacting to" ledger ":" (pr-str txn))
+      (let [ledger  (if (deref! (fluree/exists? conn ledger))
+                      (do
+                        (log/debug "transact - Ledger" ledger
+                                   "exists; loading it")
+                        (deref! (fluree/load conn ledger)))
+                      (throw (ex-info "Ledger does not exist" {:ledger ledger})))
+            address (:address ledger)
+            opts    (txn-body->opts body)
+            ;; TODO: Add a transact! fn to f.d.json-ld.api that stages and commits in one step
+            db      (-> ledger
+                        fluree/db
+                        (fluree/stage txn opts)
+                        deref!
+                        (->> (fluree/commit! ledger))
+                        deref!)]
+        {:status 200
+         :body   (-> db (select-keys [:alias :t]) (assoc :address address))}))))
+
+(def query
+  (error-catching-handler
+    (fn [{:keys [fluree/conn] {{:keys [ledger query] :as body} :body} :parameters}]
+      (let [db     (->> ledger (fluree/load conn) deref! fluree/db)
+            query* (-> query
+                       (->> (reduce-kv (fn [acc k v] (assoc acc (keyword k) v))
+                                       {}))
+                       (assoc :opts (query-body->opts body)))]
+        (log/debug "query - Querying ledger" ledger "-" query*)
+        {:status 200
+         :body   (deref! (fluree/query db query*))}))))
+
+(def history
+  (error-catching-handler
+    (fn [{:keys [fluree/conn] {{:keys [ledger query] :as body} :body} :parameters}]
+      (let [ledger* (->> ledger (fluree/load conn) deref!)
+            query*  (-> query
+                        (->> (reduce-kv (fn [acc k v] (assoc acc (keyword k) v))
+                                        {}))
+                        (assoc :opts (query-body->opts body)))]
+        (log/debug "history - Querying ledger" ledger "-" query*)
+        {:status 200
+         :body   (deref! (fluree/history ledger* query*))}))))

--- a/src/fluree/http_api/system.clj
+++ b/src/fluree/http_api/system.clj
@@ -57,12 +57,10 @@
   Returns a zero-arity fn to shut down the server."
   [{:keys [profile] :or {profile :dev} :as opts}]
   (let [cfg-overrides (dissoc opts :profile)
-        ec            (env-config profile)
-        merged-cfg    {[:env] (merge-with merge ec cfg-overrides)}]
-    (log/debug "run-server cfg-overrides:" (pr-str cfg-overrides))
-    (log/debug "run-server merged config:" (pr-str merged-cfg))
-    (let [system (ds/start profile merged-cfg)]
-      #(ds/stop system))))
+        overide-cfg   #(merge-with merge % cfg-overrides)
+        _             (log/debug "run-server cfg-overrides:" cfg-overrides)
+        system        (ds/start profile overide-cfg)]
+    #(ds/stop system)))
 
 (defn -main
   [& args]

--- a/test/fluree/http_api/system_test.clj
+++ b/test/fluree/http_api/system_test.clj
@@ -1,0 +1,119 @@
+(ns fluree.http-api.system-test
+  (:require [clojure.test :refer :all]
+            [donut.system :as ds]
+            [fluree.http-api.system :as sys]
+            [clj-http.client :as http]
+            [jsonista.core :as json]
+            [clojure.edn :as edn])
+  (:import (java.net ServerSocket)))
+
+(defn find-open-port
+  ([] (find-open-port nil))
+  ([_] ; so it can be used in swap!
+   (let [socket (ServerSocket. 0)]
+     (.close socket)
+     (.getLocalPort socket))))
+
+(defonce api-port (atom nil))
+
+(defmethod ds/named-system :test
+  [_]
+  (ds/system :dev {[:env] {:http/server {:port @api-port}
+                           :fluree/connection
+                           {:method      :memory
+                            :parallelism 1
+                            :defaults
+                            {:context
+                             {:id     "@id"
+                              :type   "@type"
+                              :ex     "http://example.com/"
+                              :schema "http://schema.org/"}}}}}))
+
+(defn run-test-server
+  [run-tests]
+  (swap! api-port find-open-port)
+  (let [stop-server (sys/run-server {:profile :test})]
+    (run-tests)
+    (stop-server)))
+
+(use-fixtures :once run-test-server)
+
+(defn api-url [endpoint]
+  (str "http://localhost:" @api-port "/fluree/" (name endpoint)))
+
+(defn post [endpoint req]
+  (http/post (api-url endpoint) (assoc req :throw-exceptions false)))
+
+(defn create-rand-ledger
+  [name-root]
+  (let [ledger-name (str name-root "-" (random-uuid))
+        req         (pr-str {:ledger  ledger-name
+                             :context {:foo "http://foobar.com/"}
+                             :txn     [{:id      :ex/create-test
+                                        :type    :foo/test
+                                        :ex/name "create-endpoint-test"}]})
+        headers     {"Content-Type" "application/edn"
+                     "Accept"       "application/edn"}
+        res         (update (post :create {:body req :headers headers})
+                            :body edn/read-string)]
+    (if (= 201 (:status res))
+      (get-in res [:body :alias])
+      (throw (ex-info "Error creating random ledger" res)))))
+
+(deftest ^:integration create-endpoint-test
+  (testing "can create a new ledger w/ JSON"
+    (let [ledger-name (str "create-endpoint-" (random-uuid))
+          address     (str "fluree:memory://" ledger-name "/main/head")
+          req         (json/write-value-as-string
+                        {:ledger  ledger-name
+                         :context {:foo "http://foobar.com/"}
+                         :txn     [{:id      :ex/create-test
+                                    :type    :foo/test
+                                    :ex/name "create-endpoint-test"}]})
+          headers     {"Content-Type" "application/json"
+                       "Accept"       "application/json"}
+          res         (post :create {:body req :headers headers})]
+      (is (= 201 (:status res)))
+      (is (= {:address address
+              :alias   ledger-name
+              :t       -1}
+             (-> res :body (json/read-value json/keyword-keys-object-mapper))))))
+  (testing "can create a new ledger w/ EDN"
+    (let [ledger-name (str "create-endpoint-" (random-uuid))
+          address     (str "fluree:memory://" ledger-name "/main/head")
+          req         (pr-str {:ledger  ledger-name
+                               :context {:foo "http://foobar.com/"}
+                               :txn     [{:id      :ex/create-test
+                                          :type    :foo/test
+                                          :ex/name "create-endpoint-test"}]})
+          headers     {"Content-Type" "application/edn"
+                       "Accept"       "application/edn"}
+          res         (post :create {:body req :headers headers})]
+      (is (= 201 (:status res)))
+      (is (= {:address address
+              :alias   ledger-name
+              :t       -1}
+             (-> res :body edn/read-string))))))
+
+;; TODO: Make load work in memory conns and then reenable
+#_(deftest ^:integration transaction-test
+    (testing "can transact in JSON"
+      (let [ledger-name (create-rand-ledger "transact-endpoint-test")
+            _           (println "RAND LEDGER:" ledger-name)
+            address     (str "fluree:memory://" ledger-name "/main/head")
+            req         (json/write-value-as-string
+                          {:ledger  ledger-name
+                           :context {:bar "http://barfoo.com/"}
+                           :txn     {:id      :ex/transaction-test
+                                     :type    :bar/test
+                                     :ex/name "transact-endpoint-test"}})
+            headers     {"Content-Type" "application/json"
+                         "Accept"       "application/json"}
+            res         (post :transact {:body req :headers headers})]
+        (is (= 200 (:status res)))
+        (is (= {:address address, :alias ledger-name, :t -2}
+               (-> res :body (json/read-value json/keyword-keys-object-mapper)))))))
+
+(deftest ^:integration query-test
+  ;; TODO
+  (is true))


### PR DESCRIPTION
So... let me know if this is just too much. I can backtrack and make some separate PRs / not do some of this.

This all started with me investigating #17 but then discovering that the bug was really down in db. By then I had already made a few small improvements in here that I'd been meaning to get to anyway.

And then I kind of was on a roll. 😬 

Here's a probably-not-exhaustive list of what this PR does:

- Actually gives an error message and status code when something goes wrong instead of always "500 error - it was an ExceptionInfo! I'm helping!"
    - in https://github.com/fluree/http-api-gateway/pull/19/commits/40ba824f27384be5264c0afd4ba02d5a17889486
- Renames API root path from `/fdb/` to `/fluree/` as this seems to be the new hotness in JSON-LD land (i.e. it matches the typical Clojure alias for the `j.d.json-ld.api` ns). If it ain't broke, break it! 
    - in https://github.com/fluree/http-api-gateway/pull/19/commits/e246f42e9259839d19f7058c479918bdb6e8e1aa
- Gets rid of `:action :new` & `:defaultContext` on the `/transact` endpoint and adds a new `/create` endpoint that takes a top-level (optional) `:context` param. The `/create` endpoint still requires an initial `:txn` to be included so that the resulting ledger is loadable from storage afterwards. 
    - in https://github.com/fluree/http-api-gateway/pull/19/commits/e79337ea7e88732f3cbb4dd6209ab3d6f3e89e5f & https://github.com/fluree/http-api-gateway/pull/19/commits/40ba824f27384be5264c0afd4ba02d5a17889486
    - This is based on DX feedback from the Nexus team and others on the core team that the old approach was kind of confusing at times.
- It uses https://github.com/fluree/db/pull/375 and so switches from `:js? true` to `:context-type :string` 
    - in https://github.com/fluree/http-api-gateway/pull/19/commits/5e566c3a62cb0f598f7d1fee6c2f5591d929316d
    - ...unless it's an EDN request in which case it uses `:context-type :keyword` so those can still work.
- It fixes an annoyance I had w/ the original config merging code where it was duplicating effort and clobbering some config you might actually want b/c I didn't fully understand how donut's config overriding worked. Now I do. A little (more).
    - in https://github.com/fluree/http-api-gateway/pull/19/commits/3b1e504a39fc07ca0fc3c39c66ce3646a6306706
- It adds a `run-dev` alias so you can start this thing in dev mode by running `clojure -X:run-dev`
    - uncredited in https://github.com/fluree/http-api-gateway/pull/19/commits/890d8cdccf0ff068c77df512c6e3138a1556df35
- It adds tests! Just two tests for the `/create` endpoint for now. Adding more will require making the `load` API fn work for memory conns (🎉) or using a file conn in the tests (☹️).
    - in https://github.com/fluree/http-api-gateway/pull/19/commits/890d8cdccf0ff068c77df512c6e3138a1556df35
    - run them with `clojure -X:test`

On the off chance this all does seem fine to the lucky reviewer(s), I'll update the README (he says hoping he'll re-read this and remember to do that before clicking that big green "merge" button).