### PR TITLE
dev tools for auto repl reloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.cpcache
 /data/*
 /target/*
+.clj-kondo/babashka
+.clj-kondo/metosin

--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,13 @@
                                          :sha     "f64bd973a5c0af7e742a80b7a75776ad3b7390a0"}}
 
  :aliases
- {:build
+ {:dev
+  {:extra-paths ["dev/src" "test"]
+   :extra-deps  {com.nextjournal/beholder    {:mvn/version "1.0.0"}
+                 org.clojure/tools.namespace {:mvn/version "1.1.0"}
+                 ring/ring-mock              {:mvn/version "0.4.0"}}}
+
+  :build
   {:deps       {io.github.seancorfield/build-clj
                 {:git/tag "v0.8.5" :git/sha "de693d0"}}
    :ns-default build}

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -1,0 +1,27 @@
+(ns dev
+  {:clj-kondo/config {:linters {:unused-namespace {:level :off}}}}
+  (:require
+   [clojure.tools.namespace.repl :as nsrepl]
+   [dev.repl :as dev-repl]
+   [donut.system :as ds]
+   [donut.system.repl :as dsr]
+   [donut.system.repl.state :as dsrs]
+   [fluree.http-api.system :as sys])
+  (:refer-clojure :exclude [test]))
+
+(nsrepl/set-refresh-dirs "dev/src" "src" "test")
+
+(defn routes
+  []
+  (get-in dsrs/system [::ds/defs :env :http/routes]))
+
+(def start dsr/start)
+(def stop dsr/stop)
+(def restart dsr/restart)
+
+(defmethod ds/named-system :donut.system/repl
+  [_]
+  (ds/system :dev))
+
+(when-not dsrs/system
+  (dsr/start))

--- a/dev/src/dev/repl.clj
+++ b/dev/src/dev/repl.clj
@@ -1,0 +1,31 @@
+(ns dev.repl
+  (:require [clojure.tools.namespace.repl :as repl]
+            [donut.system.repl :as dsr]
+            [nextjournal.beholder :as beholder]))
+
+(repl/disable-reload!)
+
+(defonce persistent-state (atom {}))
+
+(defn- source-file? [path]
+  (re-find #"(\.cljc?|\.edn)$" (str path)))
+
+(defn- restart*
+  [path]
+  (when (source-file? path)
+    (try
+      (dsr/restart)
+      (catch Exception e
+        (println "Exception reloading:")
+        (println e)))))
+
+(defn- restart [ns]
+  (fn [{:keys [path]}]
+    (binding [*ns* ns]
+      (restart* path))))
+
+(def watcher
+  (beholder/watch (restart *ns*) "src" "resources" "dev/src" "test"))
+
+(comment
+  (beholder/stop watcher))

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -1,0 +1,8 @@
+(ns user)
+
+(defn dev
+  "Load and switch to the 'dev' namespace."
+  []
+  (require 'dev)
+  (in-ns 'dev)
+  :loaded)


### PR DESCRIPTION
This PR enables the following workflow:

1. Start a REPL with the `:dev` alias. You can add `(setq cider-clojure-cli-aliases ":dev:test")` to your emacs config to have cider always add `:dev` and `:test` aliases with cider-jack-in
2. Call `(dev)` from within the `user` ns. This will load the `dev` ns and start the HTTP server. It will also make beholder start watching for file changes and reload affected namespaces and your system on each change

I don't know if you run into any issues with changes not taking effect because you haven't re-evaluated the right forms/namespaces in the right order after making a change, but if you do, this pretty much fixes that issue.