### PR TITLE
Fix history query serialization

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,12 +6,19 @@
          info.sunng/ring-jetty9-adapter {:mvn/version "0.18.1"}
          ch.qos.logback/logback-classic {:mvn/version "1.4.5"}
          org.slf4j/slf4j-api            {:mvn/version "2.0.5"}
-         metosin/reitit                 {:mvn/version "0.5.18"}
+         metosin/reitit                 {:mvn/version "0.6.0"}
+         metosin/reitit-malli           {:git/url "https://github.com/fluree/reitit.git"
+                                         :git/sha "8357e76462704eee82d75d22ba69cb316d5dc866"
+                                         :deps/root "modules/reitit-malli"}
+         metosin/reitit-swagger         {:git/url "https://github.com/fluree/reitit.git"
+                                         :git/sha "8357e76462704eee82d75d22ba69cb316d5dc866"
+                                         :deps/root "modules/reitit-swagger"}
          metosin/muuntaja               {:mvn/version "0.6.8"}
-         metosin/malli                  {:mvn/version "0.10.1"}
+         metosin/malli                  {:git/url "https://github.com/fluree/malli.git"
+                                         :git/sha "23488b20ebe189b9eae43369b4799a8940978a05"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db"
-                                         :git/sha "775623e4de608b68a70960447ac1b9317316937d"}}
+                                         :git/sha "b68662319fbdbe5f68c60409ab26db2e36aa1b08"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -10,8 +10,8 @@
          metosin/muuntaja               {:mvn/version "0.6.8"}
          metosin/malli                  {:mvn/version "0.10.1"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
-         com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "f0c10635d6a99e791d59676e7ed4191e82083486"}}
+         com.fluree/db                  {:git/url "https://github.com/fluree/db"
+                                         :git/sha "775623e4de608b68a70960447ac1b9317316937d"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -8,10 +8,10 @@
          org.slf4j/slf4j-api            {:mvn/version "2.0.5"}
          metosin/reitit                 {:mvn/version "0.5.18"}
          metosin/muuntaja               {:mvn/version "0.6.8"}
-         metosin/spec-tools             {:mvn/version "0.10.5"}
+         metosin/malli                  {:mvn/version "0.10.1"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :sha     "9e9718b11e954c47621ea2c4651105f6d0765535"}}
+                                         :git/sha "f0c10635d6a99e791d59676e7ed4191e82083486"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -15,9 +15,9 @@
                                          :deps/root "modules/reitit-swagger"}
          metosin/muuntaja               {:mvn/version "0.6.8"}
          metosin/malli                  {:git/url "https://github.com/fluree/malli.git"
-                                         :git/sha "23488b20ebe189b9eae43369b4799a8940978a05"}
+                                         :git/sha "58f7e067e3742b0bc9b9c2669aa35d54de247e25"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
-         com.fluree/db                  {:git/url "https://github.com/fluree/db"
+         com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
                                          :git/sha "b68662319fbdbe5f68c60409ab26db2e36aa1b08"}}
 
  :aliases

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -18,4 +18,5 @@
                                          #profile {:dev
                                                    {:id   "@id"
                                                     :type "@type"
+                                                    :f    "https://ns.flur.ee/ledger#"
                                                     :ex   "http://example.com/"}}]}}}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,7 +1,7 @@
-{:http/server       {:port #or [#env FLUREE_HTTP_API_PORT
-                                #profile {:dev    58090
-                                          :prod   8090
-                                          :docker 8090}]}
+{:http/server       {:port #long #or [#env FLUREE_HTTP_API_PORT
+                                      #profile {:dev    58090
+                                                :prod   8090
+                                                :docker 8090}]}
  :fluree/connection {:method       #or [#env FLUREE_STORAGE_METHOD
                                         #profile {:dev    :file
                                                   :prod   :ipfs

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -205,9 +205,9 @@
         {:data {:coercion   reitit.coercion.malli/coercion
                 :muuntaja   muuntaja/instance
                 :middleware [swagger/swagger-feature
-                             muuntaja/format-negotiate-middleware
-                             muuntaja/format-response-middleware
-                             muuntaja/format-request-middleware]}})
+                             muuntaja-mw/format-negotiate-middleware
+                             muuntaja-mw/format-response-middleware
+                             muuntaja-mw/format-request-middleware]}})
       (ring/routes
         (ring/ring-handler
           (ring/router

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -1,7 +1,6 @@
 (ns fluree.http-api.components.http
   (:require
     [donut.system :as ds]
-    [jsonista.core :as j]
     [ring.adapter.jetty9 :as http]
     [reitit.ring :as ring]
     [reitit.coercion.malli]
@@ -12,8 +11,6 @@
     [reitit.ring.middleware.exception :as exception]
     [fluree.http-api.handlers.ledger :as ledger]
     [muuntaja.core :as muuntaja]
-    [muuntaja.format.json :as json-format]
-    [muuntaja.format.core :as mf]
     [ring.middleware.cors :as rmc]
     [fluree.db.util.log :as log]
     [malli.core :as m]

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -17,17 +17,17 @@
     [malli.experimental.lite :as l]
     [fluree.db.query.history :as fqh :refer [HistoryQuery]]
     [fluree.db.query.fql.syntax :as fql]
-    [fluree.db.json-ld.transact :as ftx]))
+    [fluree.db.json-ld.transact :as ftx]
+    [fluree.db.util.validation :as v]))
 
 (set! *warn-on-reflection* true)
 
 ;; TODO: Flesh this out some more
-(def non-empty-string (m/schema [:string {:min 1}]))
-(def address non-empty-string)
-(def id non-empty-string)
+(def address v/non-empty-string)
+(def id v/non-empty-string)
 (def natural-int (m/schema [:int {:min 0}]))
 (def t natural-int)
-(def ledger-alias non-empty-string)
+(def ledger-alias v/non-empty-string)
 (def txn (m/schema ::ftx/txn {:registry ftx/registry}))
 (def context (m/schema [:map-of :keyword :any]))
 
@@ -51,8 +51,8 @@
                                          {:registry fql/registry})}}
    :responses  {200 {:body (m/schema ::fql/query-results
                                      {:registry fql/registry})}
-                400 {:body non-empty-string}
-                500 {:body non-empty-string}}
+                400 {:body v/non-empty-string}
+                500 {:body v/non-empty-string}}
    :handler    ledger/query})
 
 (def multi-query-endpoint
@@ -62,8 +62,8 @@
                                          {:registry fql/registry})}}
    :responses  {200 {:body (m/schema ::fql/multi-query-results
                                      {:registry fql/registry})}
-                400 {:body non-empty-string}
-                500 {:body non-empty-string}}
+                400 {:body v/non-empty-string}
+                500 {:body v/non-empty-string}}
    :handler    ledger/multi-query})
 
 (def history-endpoint
@@ -72,8 +72,8 @@
                        :query  HistoryQuery}}
    :responses  {200 {:body (m/schema ::fqh/history-query-results
                                      {:registry fqh/registry})}
-                400 {:body non-empty-string}
-                500 {:body non-empty-string}}
+                400 {:body v/non-empty-string}
+                500 {:body v/non-empty-string}}
    :handler    ledger/history})
 
 (defn wrap-assoc-conn
@@ -179,8 +179,8 @@
                                             [:t t]
                                             [:address {:optional true} address]
                                             [:id {:optional true} id]]}
-                                400 {:body non-empty-string}
-                                500 {:body non-empty-string}}
+                                400 {:body v/non-empty-string}
+                                500 {:body v/non-empty-string}}
                    :handler    ledger/create}}]
           ["/transact"
            {:post {:summary    "Endpoint for submitting transactions"
@@ -190,8 +190,8 @@
                                             :t       t
                                             :address (l/optional address)
                                             :id      (l/optional id)}}
-                                400 {:body [:or map? non-empty-string]}
-                                500 {:body [:or map? non-empty-string]}}
+                                400 {:body [:or map? v/non-empty-string]}
+                                500 {:body [:or map? v/non-empty-string]}}
                    :handler    ledger/transact}}]
           ["/query"
            {:get  query-endpoint

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -123,15 +123,15 @@
 
 (def multi-query
   (error-catching-handler
-   (fn [{:keys [fluree/conn] {{:keys [ledger query] :as body} :body} :parameters}]
-     (let [db     (->> ledger (fluree/load conn) deref! fluree/db)
-           query* (-> (reduce-kv (fn [m k v]
-                                   (assoc m k (keywordize-keys v)))
-                                 {} query)
-                      (assoc :opts (query-body->opts body)))]
-       (log/debug "multi-query - Querying ledger" ledger "-" query)
-       {:status 200
-        :body   (deref! (fluree/multi-query db query*))}))))
+    (fn [{:keys [fluree/conn] {{:keys [ledger query] :as body} :body} :parameters}]
+      (let [db     (->> ledger (fluree/load conn) deref! fluree/db)
+            query* (-> (reduce-kv (fn [m k v]
+                                    (assoc m k (keywordize-keys v)))
+                                  {} query)
+                       (assoc :opts (query-body->opts body)))]
+        (log/debug "multi-query - Querying ledger" ledger "-" query)
+        {:status 200
+         :body   (deref! (fluree/multi-query db query*))}))))
 
 
 (def history

--- a/test/fluree/http_api/system_test.clj
+++ b/test/fluree/http_api/system_test.clj
@@ -75,7 +75,8 @@
           headers     {"Content-Type" "application/json"
                        "Accept"       "application/json"}
           res         (post :create {:body req :headers headers})]
-      (is (= 201 (:status res)))
+      (is (= 201 (:status res))
+          (str "Response was: " (pr-str res)))
       (is (= {:address address
               :alias   ledger-name
               :t       1}
@@ -92,7 +93,8 @@
           headers     {"Content-Type" "application/edn"
                        "Accept"       "application/edn"}
           res         (post :create {:body req :headers headers})]
-      (is (= 201 (:status res)))
+      (is (= 201 (:status res))
+          (str "Response was: " (pr-str res)))
       (is (= {:address address
               :alias   ledger-name
               :t       1}
@@ -109,8 +111,10 @@
                        "Accept"       "application/edn"}
           res-success (post :create {:body req :headers headers})
           _           (assert (= 201 (:status res-success)))
+          _           (Thread/sleep 100) ; gross; replace w/ retries
           res-fail    (post :create {:body req :headers headers})]
-      (is (= 409 (:status res-fail))))))
+      (is (= 409 (:status res-fail))
+          (str "Response was: " (pr-str res-fail))))))
 
 (deftest ^:integration transaction-test
   (testing "can transact in JSON"
@@ -124,9 +128,10 @@
           headers     {"Content-Type" "application/json"
                        "Accept"       "application/json"}
           res         (post :transact {:body req :headers headers})]
-      (is (= 200 (:status res)))
-      (is (= {:address address, :alias ledger-name, :t 2}
-             (-> res :body (json/read-value json/keyword-keys-object-mapper))))))
+      (is (= 200 (:status res))
+          (str "Response was: " (pr-str res)))
+      (is (= {"address" address, "alias" ledger-name, "t" 2}
+             (-> res :body json/read-value)))))
 
   (testing "can transact in EDN"
     (let [ledger-name (create-rand-ledger "transact-endpoint-edn-test")
@@ -139,12 +144,13 @@
           headers     {"Content-Type" "application/edn"
                        "Accept"       "application/edn"}
           res         (post :transact {:body req :headers headers})]
-      (is (= 200 (:status res)))
+      (is (= 200 (:status res))
+          (str "Response was: " (pr-str res)))
       (is (= {:address address, :alias ledger-name, :t 2}
              (-> res :body edn/read-string))))))
 
 (deftest ^:integration query-test
-  (testing "can query a basic entity"
+  (testing "can query a basic entity w/ EDN"
     (let [ledger-name (create-rand-ledger "query-endpoint-basic-entity-test")
           edn-headers {"Content-Type" "application/edn"
                        "Accept"       "application/edn"}
@@ -162,8 +168,183 @@
                                          :where  '[[?t :type :schema/Test]]}})
                        :headers edn-headers}
           query-res   (post :query query-req)]
-      (is (= 200 (:status query-res)))
+      (is (= 200 (:status query-res))
+          (str "Response was: " (pr-str query-res)))
       (is (= [{:id       :ex/query-test
                :rdf/type [:schema/Test]
                :ex/name  "query-test"}]
-             (-> query-res :body edn/read-string))))))
+             (-> query-res :body edn/read-string)))))
+
+  (testing "can query a basic entity w/ JSON"
+    (let [ledger-name  (create-rand-ledger "query-endpoint-basic-entity-test")
+          json-headers {"Content-Type" "application/json"
+                        "Accept"       "application/json"}
+          txn-req      {:body
+                        (json/write-value-as-string
+                          {:ledger ledger-name
+                           :txn    [{:id      :ex/query-test
+                                     :type    :schema/Test
+                                     :ex/name "query-test"}]})
+                        :headers json-headers}
+          txn-res      (post :transact txn-req)
+          _            (assert (= 200 (:status txn-res)))
+          query-req    {:body
+                        (json/write-value-as-string
+                          {:ledger ledger-name
+                           :query  {:select '{?t [:*]}
+                                    :where  '[[?t :type "schema/Test"]]}})
+                        :headers json-headers}
+          query-res    (post :query query-req)]
+      (is (= 200 (:status query-res))
+          (str "Response was: " (pr-str query-res)))
+      (is (= [{:id       "ex/query-test"
+               :rdf/type ["schema/Test"]
+               :ex/name  "query-test"}]
+             (-> query-res :body
+                 (json/read-value json/keyword-keys-object-mapper)))))))
+
+(deftest ^:integration multi-query-test
+  (testing "can run a multi-query w/ EDN"
+    (let [ledger-name (create-rand-ledger "multi-query-endpoint-test")
+          edn-headers {"Content-Type" "application/edn"
+                       "Accept"       "application/edn"}
+          txn-req     {:body    (pr-str
+                                  {:ledger ledger-name
+                                   :txn    [{:id       :ex/wes
+                                             :type     :schema/Person
+                                             :ex/fname "Wes"}
+                                            {:id       :ex/ben
+                                             :type     :schema/Person
+                                             :ex/fname "Ben"}]})
+                       :headers edn-headers}
+          {txn-status :status} (post :transact txn-req)
+          _           (assert (= 200 txn-status))
+          query-req   {:body    (pr-str
+                                  {:ledger ledger-name
+                                   :query
+                                   {:wes {:select '{?p [:*]}
+                                          :where  '[[?p :ex/fname "Wes"]]}
+                                    :ben {:select '{?p [:*]}
+                                          :where  '[[?p :ex/fname "Ben"]]}}})
+                       :headers edn-headers}
+          query-res   (post :multi-query query-req)]
+      (is (= 200 (:status query-res))
+          (str "Response was: " (pr-str query-res)))
+      (is (= {:ben [{:id :ex/ben, :ex/fname "Ben", :rdf/type [:schema/Person]}]
+              :wes [{:id :ex/wes, :ex/fname "Wes", :rdf/type [:schema/Person]}]}
+             (-> query-res :body edn/read-string)))))
+
+  (testing "can run a multi-query w/ JSON"
+    (let [ledger-name  (create-rand-ledger "multi-query-endpoint-test")
+          json-headers {"Content-Type" "application/json"
+                        "Accept"       "application/json"}
+          txn-req      {:body (json/write-value-as-string
+                                {:ledger ledger-name
+                                 :txn [{:id       :ex/wes
+                                        :type     :schema/Person
+                                        :ex/fname "Wes"}
+                                       {:id       :ex/ben
+                                        :type     :schema/Person
+                                        :ex/fname "Ben"}]})
+                        :headers json-headers}
+          {txn-status :status} (post :transact txn-req)
+          _            (assert (= 200 txn-status))
+          query-req    {:body (json/write-value-as-string
+                                {:ledger ledger-name
+                                 :query
+                                 {:wes {:select '{?p [:*]}
+                                        :where  '[[?p :ex/fname "Wes"]]}
+                                  :ben {:select '{?p [:*]}
+                                        :where  '[[?p :ex/fname "Ben"]]}}})
+                        :headers json-headers}
+          query-res     (post :multi-query query-req)]
+      (is (= 200 (:status query-res))
+          (str "Response was: " (pr-str query-res)))
+      (is (= {:ben [{:id "ex/ben", :ex/fname "Ben", :rdf/type ["schema/Person"]}]
+              :wes [{:id "ex/wes", :ex/fname "Wes", :rdf/type ["schema/Person"]}]}
+             (-> query-res :body
+                 (json/read-value json/keyword-keys-object-mapper)))))))
+
+(deftest ^:integration history-query-test
+  (testing "can run a history query w/ EDN"
+    (let [ledger-name (create-rand-ledger "history-query-endpoint-test")
+          edn-headers {"Content-Type" "application/edn"
+                       "Accept"       "application/edn"}
+          base-req    {:headers edn-headers}
+          txn1-req    (assoc base-req
+                        :body (pr-str
+                                {:ledger ledger-name
+                                 :txn    [{:id       :ex/history-test
+                                           :type     :schema/Test
+                                           :ex/fname "Wes"}]}))
+          {txn1-status :status} (post :transact txn1-req)
+          _           (assert (= 200 txn1-status))
+          txn2-req    (assoc base-req
+                        :body (pr-str
+                                {:ledger ledger-name
+                                 :txn    [{:id       :ex/history-test
+                                           :ex/lname "Morgan"}]}))
+          {txn2-status :status} (post :transact txn2-req)
+          _           (assert (= 200 txn2-status))
+          txn3-req    (assoc base-req
+                        :body (pr-str
+                                {:ledger ledger-name
+                                 :txn    [{:id     :ex/history-test
+                                           :ex/age 42}]}))
+          {txn3-status :status} (post :transact txn3-req)
+          _           (assert (= 200 txn3-status))
+          query-req   (assoc base-req
+                        :body (pr-str
+                                {:ledger ledger-name
+                                 :query  {:commit-details true
+                                          :t              {:at :latest}}}))
+          query-res   (post :history query-req)]
+      (is (= 200 (:status query-res))
+          (str "Response was: " (pr-str query-res)))
+      (is (= [{:f/commit
+               {:f/data
+                {:f/assert  [{:id :ex/history-test, :ex/age 42}]
+                 :f/retract []}}}]
+             (-> query-res :body edn/read-string)))))
+
+  (testing "can run a history query w/ JSON"
+    (let [ledger-name  (create-rand-ledger "history-query-endpoint-test")
+          json-headers {"Content-Type" "application/json"
+                        "Accept"       "application/json"}
+          base-req     {:headers json-headers}
+          txn1-req     (assoc base-req
+                         :body (json/write-value-as-string
+                                 {:ledger ledger-name
+                                  :txn    [{:id       :ex/history-test
+                                            :type     :schema/Test
+                                            :ex/fname "Wes"}]}))
+          {txn1-status :status} (post :transact txn1-req)
+          _            (assert (= 200 txn1-status))
+          txn2-req     (assoc base-req
+                         :body (json/write-value-as-string
+                                 {:ledger ledger-name
+                                  :txn    [{:id       :ex/history-test
+                                            :ex/lname "Morgan"}]}))
+          {txn2-status :status} (post :transact txn2-req)
+          _            (assert (= 200 txn2-status))
+          txn3-req     (assoc base-req
+                         :body (json/write-value-as-string
+                                 {:ledger ledger-name
+                                  :txn    [{:id     :ex/history-test
+                                            :ex/age 42}]}))
+          {txn3-status :status} (post :transact txn3-req)
+          _            (assert (= 200 txn3-status))
+          query-req    (assoc base-req
+                         :body (json/write-value-as-string
+                                 {:ledger ledger-name
+                                  :query  {:commit-details true
+                                           :t              {:at :latest}}}))
+          query-res    (post :history query-req)]
+      (is (= 200 (:status query-res))
+          (str "Response was: " (pr-str query-res)))
+      (is (= [{:f/commit
+               {:f/data
+                {:f/assert  [{:id "ex/history-test", :ex/age 42}]
+                 :f/retract []}}}]
+             (-> query-res :body
+                 (json/read-value json/keyword-keys-object-mapper)))))))

--- a/test/fluree/http_api/system_test.clj
+++ b/test/fluree/http_api/system_test.clj
@@ -28,6 +28,7 @@
                               :type   "@type"
                               :ex     "http://example.com/"
                               :schema "http://schema.org/"
+                              :f      "https://ns.flur.ee/ledger#"
                               :rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"}}}}}))
 
 (defn run-test-server


### PR DESCRIPTION
Fixes #25 

Closes #12 

Likely also fixes #28 (and based on some quick testing it does seem to)

Swaps out clojure.spec for malli, uses the malli specs already defined in db, and then coerces requests to those instead of using a custom json formatter.

Currently relies on https://github.com/fluree/db/pull/400 but that could be easily changed if that doesn't get approved.