### PR TITLE
history query keywordization

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/spec-tools             {:mvn/version "0.10.5"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :sha     "8775f13efae89735defbc5bb9eb8378c19075b43"}}
+                                         :sha     "14a22cd27ec473c9ab86dd8bf26619cb6319fc94"}}
 
  :aliases
  {:dev

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,7 +1,7 @@
-{:http/server       {:port #or [#env FLUREE_HTTP_API_PORT
-                                #profile {:dev    58090
-                                          :prod   8090
-                                          :docker 8090}]}
+{:http/server       {:port #long #or [#env FLUREE_HTTP_API_PORT
+                                      #profile {:dev    58090
+                                                :prod   8090
+                                                :docker 8090}]}
  :fluree/connection {:method       #or [#env FLUREE_STORAGE_METHOD
                                         #profile {:dev    :file
                                                   :prod   :ipfs

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -150,16 +150,15 @@
   ([q]
    (keywordize-history-query q #{"commit-details" "t" "history"}))
   ([q kws]
-   (let []
-     (reduce-kv
-       (fn [q k v]
-         (let [k* (if (kws k) (keyword k) k)
-               v* (case k
-                    "t" (keywordize-history-query v #{"at" "from" "to"})
-                    v)]
-           (assoc q k* v*)))
-       {}
-       q))))
+   (reduce-kv
+     (fn [q k v]
+       (let [k* (if (kws k) (keyword k) k)
+             v* (case k
+                  "t" (keywordize-history-query v #{"at" "from" "to"})
+                  v)]
+         (assoc q k* v*)))
+     {}
+     q)))
 
 (def history
   (error-catching-handler

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -152,9 +152,11 @@
   ([q kws]
    (reduce-kv
      (fn [q k v]
-       (let [k* (if (kws k) (keyword k) k)
-             v* (case k
-                  "t" (keywordize-history-query v #{"at" "from" "to"})
+       (let [k* (if (kws k)
+                  (keyword k)
+                  k)
+             v* (if (= "t" k)
+                  (keywordize-history-query v #{"at" "from" "to"})
                   v)]
          (assoc q k* v*)))
      {}


### PR DESCRIPTION
This is a dumb solution that builds off of PR #39 with only minor changes, in order to fix #25.

These are the minor changes:
- I changed the `db` dependency so the history query doesn't look for a keyword `:latest` value for the `:t` keys (`:at` `:to` `:from`) (https://github.com/fluree/db/pull/425 should be merged first)
- this allowed me to simplify the keywordization function

This does not address the incomplete commit details results shown in #32.