### PR TITLE
Override handlers, add additional vars into http environment

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/spec-tools             {:mvn/version "0.10.5"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :sha     "14a22cd27ec473c9ab86dd8bf26619cb6319fc94"}}
+                                         :sha     "e1d802cd13607318cdf21443b021f83dd50e1032"}}
 
  :aliases
  {:dev

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -163,7 +163,7 @@
         resp))))
 
 (defn app
-  [{:keys [:fluree/conn :http/middleware :http/routes]}]
+  [{:keys [:fluree/conn :fluree/consensus :http/middleware :http/routes :http/tx-handler :http/create-handler] :as cfg}]
   (log/debug "HTTP server running with Fluree connection:" conn
              "- middleware:" middleware "- routes:" routes)
   (let [default-fluree-middleware [[10 wrap-cors]
@@ -199,7 +199,9 @@
                                                    :req-un [::alias ::t])}
                                 400 {:body string?}
                                 500 {:body string?}}
-                   :handler    ledger/create}}]
+                   :handler    (if create-handler
+                                 (create-handler cfg)
+                                 ledger/create)}}]
           ["/transact"
            {:post {:summary    "Endpoint for submitting transactions"
                    :parameters {:body (s/keys :req-un [::ledger ::txn])}
@@ -207,7 +209,9 @@
                                                    :req-un [::alias ::t])}
                                 400 {:body string?}
                                 500 {:body string?}}
-                   :handler    ledger/transact}}]
+                   :handler    (if tx-handler
+                                 (tx-handler cfg)
+                                 ledger/transact)}}]
           ["/query"
            {:get  query-endpoint
             :post query-endpoint}]

--- a/src/fluree/http_api/system.clj
+++ b/src/fluree/http_api/system.clj
@@ -13,21 +13,19 @@
 
 (def base-system
   {::ds/defs
-   {:env
-    {:http/server {}}
-    :fluree
-    {:conn fluree/conn}
-    :http
-    {:server  http/server
-     :handler #::ds{:start  (fn [{{:keys [:fluree/connection] :as cfg
-                                   {:keys [routes middleware]} :http}
-                                  ::ds/config}]
-                              (log/debug "ds/config:" cfg)
-                              (http/app {:fluree/conn     connection
-                                         :http/routes     routes
-                                         :http/middleware middleware}))
-                    :config {:http              (ds/ref [:env :http/server])
-                             :fluree/connection (ds/ref [:fluree :conn])}}}}})
+   {:env    {:http/server {}}
+    :fluree {:conn fluree/conn}
+    :http   {:server  http/server
+             :handler #::ds{:start  (fn [{{:keys [:fluree/connection :fluree/consensus] :as cfg {:keys [routes middleware tx-handler create-handler]} :http} ::ds/config}]
+                                      (log/debug "ds/config:" cfg)
+                                      (http/app {:fluree/conn         connection
+                                                 :fluree/consensus    consensus
+                                                 :http/routes         routes
+                                                 :http/middleware     middleware
+                                                 :http/tx-handler     tx-handler
+                                                 :http/create-handler create-handler}))
+                            :config {:http              (ds/ref [:env :http/server])
+                                     :fluree/connection (ds/ref [:fluree :conn])}}}}})
 
 (defmethod ds/named-system :base
   [_]


### PR DESCRIPTION
This allows for the transact and create API handlers to get replaced. When a consensus server needs to handle these operations, consensus ends up calling the various API calls and needs to inject its own handler into the process.

Also, this adds a number of consensus-related vars into the HTTP server's environments so API calls can implement consensus.

I realize this repo has nothing to do with consensus, just not sure how to get needed consensus components into the HTTP server any other way.

The other item that still needs to get done is the API formats themselves change in consensus. I couldn't change them here as it would break this repo, so for now I left them breaking the Consensus Server repo. It seemed a bridge too far to also allow those to be overridden because at that point quite a lot of the code here ends up not being used. Not sure best approach, but would love any suggestions.

The tests here are not passing, but I checked and they don't seem to be passing (for me anyhow) before these changes.