### PR TITLE
Feature: Use new db context handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,7 @@ jobs:
           target: builder
           load: true
       - name: Run tests
-        #run: docker run fluree/http-api-gateway clojure -X:test
-        run: 'docker run fluree/http-api-gateway clojure -X:test :kaocha.filter/focus-meta [:json]'
+        run: docker run fluree/http-api-gateway clojure -X:test
 
   notifications:
     name: send notifications

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/spec-tools             {:mvn/version "0.10.5"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :sha     "dabce6c2afa45e55118a32a157edd5ae53694367"}}
+                                         :git/sha "4fec21b7260f1404ea4b184a1fc2820135f8ab5c"}}
 
  :aliases
  {:dev

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -31,7 +31,7 @@
                       :strings #{"new" "insert"}))
 (s/def ::ledger ::non-empty-string)
 (s/def ::txn (s/or :single-map map? :collection-of-maps (s/coll-of map?)))
-(s/def ::context map?)
+(s/def ::defaultContext any?)
 
 (def server
   #::ds{:start  (fn [{{:keys [handler options]} ::ds/config}]
@@ -193,7 +193,7 @@
          ["/fluree" {:middleware fluree-middleware}
           ["/create"
            {:post {:summary    "Endpoint for creating new ledgers"
-                   :parameters {:body (s/keys :opt-un [::context]
+                   :parameters {:body (s/keys :opt-un [::defaultContext]
                                               :req-un [::ledger ::txn])}
                    :responses  {201 {:body (s/keys :opt-un [::address ::id]
                                                    :req-un [::alias ::t])}

--- a/test/fluree/http_api/system_test.clj
+++ b/test/fluree/http_api/system_test.clj
@@ -247,7 +247,7 @@
                        (pr-str
                         {:ledger ledger-name
                          :query  {:commit-details true
-                                  :t              {:at :latest}}})
+                                  :t              {:at "latest"}}})
                        :headers edn-headers}
           query-res   (post :history query-req)]
       (is (= 200 (:status query-res))

--- a/test/fluree/http_api/system_test.clj
+++ b/test/fluree/http_api/system_test.clj
@@ -49,11 +49,11 @@
 (defn create-rand-ledger
   [name-root]
   (let [ledger-name (str name-root "-" (random-uuid))
-        req         (pr-str {:ledger  ledger-name
-                             :context {:foo "http://foobar.com/"}
-                             :txn     [{:id      :ex/create-test
-                                        :type    :foo/test
-                                        :ex/name "create-endpoint-test"}]})
+        req         (pr-str {:ledger         ledger-name
+                             :defaultContext ["" {:foo "http://foobar.com/"}]
+                             :txn            [{:id      :ex/create-test
+                                               :type    :foo/test
+                                               :ex/name "create-endpoint-test"}]})
         headers     {"Content-Type" "application/edn"
                      "Accept"       "application/edn"}
         res         (update (post :create {:body req :headers headers})
@@ -67,11 +67,11 @@
     (let [ledger-name (str "create-endpoint-" (random-uuid))
           address     (str "fluree:memory://" ledger-name "/main/head")
           req         (json/write-value-as-string
-                       {"ledger"  ledger-name
-                        "context" {"foo" "http://foobar.com/"}
-                        "txn"     [{"id"      "ex:create-test"
-                                    "type"    "foo:test"
-                                    "ex:name" "create-endpoint-test"}]})
+                       {"ledger"         ledger-name
+                        "defaultContext" ["" {"foo" "http://foobar.com/"}]
+                        "txn"            [{"id"      "ex:create-test"
+                                           "type"    "foo:test"
+                                           "ex:name" "create-endpoint-test"}]})
           headers     {"Content-Type" "application/json"
                        "Accept"       "application/json"}
           res         (post :create {:body req :headers headers})]
@@ -85,11 +85,11 @@
   (testing "can create a new ledger w/ EDN"
     (let [ledger-name (str "create-endpoint-" (random-uuid))
           address     (str "fluree:memory://" ledger-name "/main/head")
-          req         (pr-str {:ledger  ledger-name
-                               :context {:foo "http://foobar.com/"}
-                               :txn     [{:id      :ex/create-test
-                                          :type    :foo/test
-                                          :ex/name "create-endpoint-test"}]})
+          req         (pr-str {:ledger         ledger-name
+                               :defaultContext ["" {:foo "http://foobar.com/"}]
+                               :txn            [{:id      :ex/create-test
+                                                 :type    :foo/test
+                                                 :ex/name "create-endpoint-test"}]})
           headers     {"Content-Type" "application/edn"
                        "Accept"       "application/edn"}
           res         (post :create {:body req :headers headers})]
@@ -101,11 +101,11 @@
 
   (testing "responds with 409 error if ledger already exists"
     (let [ledger-name (str "create-endpoint-" (random-uuid))
-          req         (pr-str {:ledger  ledger-name
-                               :context {:foo "http://foobar.com/"}
-                               :txn     [{:id      :ex/create-test
-                                          :type    :foo/test
-                                          :ex/name "create-endpoint-test"}]})
+          req         (pr-str {:ledger         ledger-name
+                               :defaultContext ["" {:foo "http://foobar.com/"}]
+                               :txn            [{:id      :ex/create-test
+                                                 :type    :foo/test
+                                                 :ex/name "create-endpoint-test"}]})
           headers     {"Content-Type" "application/edn"
                        "Accept"       "application/edn"}
           res-success (post :create {:body req :headers headers})


### PR DESCRIPTION
https://github.com/fluree/db/pull/437 introduces a new `:defaultContext` key in the create API that doesn't merge with conn default contexts unless you explicitly request that via a `["" {...}]` structure.

This updates http-api-gateway to work with that. All of the tests now pass in this branch pointed at the `fix/context` branch of db (plus one other small change in the history query test; `:latest` => `"latest"`).