### PR TITLE
Sync with latest db

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.11.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "e84bf096a4a8bd0e0c9055265b7c4a1806cedd98"}}
+                                         :git/sha "a34692d29637ae624bf8eab98216ead6f20c998d"}}
 
  :aliases
  {:dev

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -112,10 +112,7 @@
     (fn [{:keys [fluree/conn content-type] {{:keys [ledger query] :as body} :body} :parameters}]
       (log/debug "query handler received body:" body)
       (let [db     (->> ledger (fluree/load conn) deref! fluree/db)
-            query* (-> query
-                       (->> (reduce-kv (fn [acc k v] (assoc acc (keyword k) v))
-                                       {}))
-                       (assoc :opts (query-body->opts body content-type)))]
+            query* (assoc query :opts (query-body->opts body content-type))]
         (log/debug "query - Querying ledger" ledger "-" query*)
         {:status 200
          :body   (deref! (fluree/query db query*))}))))
@@ -124,10 +121,7 @@
   (error-catching-handler
    (fn [{:keys [fluree/conn content-type] {{:keys [ledger query] :as body} :body} :parameters}]
      (let [db     (->> ledger (fluree/load conn) deref! fluree/db)
-           query* (-> (reduce-kv (fn [m k v]
-                                   (assoc m k (util/keywordize-keys v)))
-                                 {} query)
-                      (assoc :opts (query-body->opts body content-type)))]
+           query* (assoc query :opts (query-body->opts body content-type))]
        (log/debug "multi-query - Querying ledger" ledger "-" query)
        {:status 200
         :body   (deref! (fluree/multi-query db query*))}))))

--- a/test/fluree/http_api/system_test.clj
+++ b/test/fluree/http_api/system_test.clj
@@ -40,6 +40,18 @@
 
 (use-fixtures :once run-test-server)
 
+(def commit-id-regex
+  (re-pattern "fluree:commit:sha256:[a-z2-7]{52,53}"))
+
+(def mem-addr-regex
+  (re-pattern "fluree:memory://[a-f0-9]{64}"))
+
+(def context-id-regex
+  (re-pattern "fluree:context:[a-f0-9]{64}"))
+
+(def db-id-regex
+  (re-pattern "fluree:db:sha256:[a-z2-7]{52,53}"))
+
 (defn api-url [endpoint]
   (str "http://localhost:" @api-port "/fluree/" (name endpoint)))
 
@@ -297,67 +309,120 @@
 
 (deftest ^:integration ^:json history-query-json-test
   (testing "basic JSON history query works"
-    (let [ledger-name  (create-rand-ledger "history-query-basic-test")
-          json-headers {"Content-Type" "application/json"
-                        "Accept"       "application/json"}
-          txn-req      {:body
-                        (json/write-value-as-string
-                         {"ledger" ledger-name
-                          "txn"    [{"id"      "ex:query-test"
-                                     "type"    "schema:Test"
-                                     "ex:name" "query-test"}]})
-                        :headers json-headers}
-          txn-res      (post :transact txn-req)
-          _            (assert (= 200 (:status txn-res)))
-          query-req    {:body
-                        (json/write-value-as-string
-                         {"ledger" ledger-name
-                          "query"  {"commit-details" true
-                                    "t"              {"at" "latest"}}})
-                        :headers json-headers}
-          query-res    (post :history query-req)]
+    (let [ledger-name   "history-query-json-test"
+          json-headers  {"Content-Type" "application/json"
+                         "Accept"       "application/json"}
+          txn-req       {:body
+                         (json/write-value-as-string
+                          {"ledger" ledger-name
+                           "txn"    [{"id"      "ex:query-test"
+                                      "type"    "schema:Test"
+                                      "ex:name" "query-test"}]})
+                         :headers json-headers}
+          txn-res       (post :create txn-req)
+          _             (assert (= 201 (:status txn-res)))
+          txn2-req      {:body
+                         (json/write-value-as-string
+                          {"ledger" ledger-name
+                           "txn"    [{"id"           "ex:query-test"
+                                      "ex:test-type" "integration"}]})
+                         :headers json-headers}
+          txn2-res      (post :transact txn2-req)
+          _             (assert (= 200 (:status txn2-res)))
+          query-req     {:body
+                         (json/write-value-as-string
+                          {"ledger" ledger-name
+                           "query"  {"commit-details" true
+                                     "t"              {"at" "latest"}}})
+                         :headers json-headers}
+          query-res     (post :history query-req)
+          query-results (-> query-res :body json/read-value)]
       (is (= 200 (:status query-res))
           (str "History query response was: " (pr-str query-res)))
-      (is (= [{"f:commit"
-               {"f:data"
-                {"f:assert"
-                 [{"ex:name"  "query-test"
-                   "id"       "ex:query-test"
-                   "rdf:type" ["schema:Test"]}]
-                 "f:retract" []}}}]
-             (-> query-res :body json/read-value))))))
+      (let [history-expectations
+            {["id"]                  #(re-matches commit-id-regex %)
+             ["f:address"]           #(re-matches mem-addr-regex %)
+             ["f:alias"]             #(= % ledger-name)
+             ["f:branch"]            #(= % "main")
+             ["f:defaultContext"]    #(re-matches context-id-regex (get % "id"))
+             ["f:previous"]          #(or (nil? %)
+                                          (re-matches commit-id-regex (get % "id")))
+             ["f:time"]              pos-int?
+             ["f:v"]                 nat-int?
+             ["f:data" "f:address"]  #(re-matches mem-addr-regex %)
+             ["f:data" "f:assert"]   #(and (vector? %) (every? map? %))
+             ["f:data" "f:retract"]  #(and (vector? %) (every? map? %))
+             ["f:data" "f:flakes"]   pos-int?
+             ["f:data" "f:size"]     pos-int?
+             ["f:data" "f:t"]        pos-int?
+             ["f:data" "f:previous"] #(or (nil? %)
+                                          (re-matches db-id-regex (get % "id")))}]
+        (is (every? #(every? (fn [[kp valid?]]
+                               (let [actual (get-in % kp)]
+                                 (or
+                                  (valid? actual)
+                                  (println "invalid:" (pr-str actual)))))
+                             history-expectations)
+                    (map #(get % "f:commit") query-results)))))))
+
 
 (deftest ^:integration ^:edn history-query-edn-test
   (testing "basic EDN history query works"
-    (let [ledger-name (create-rand-ledger "history-query-basic-test")
-          edn-headers {"Content-Type" "application/edn"
-                       "Accept"       "application/edn"}
-          txn-req     {:body
-                       (pr-str
-                        {:ledger ledger-name
-                         :txn    [{:id      :ex/query-test
-                                   :type    :schema/Test
-                                   :ex/name "query-test"}]})
-                       :headers edn-headers}
-          txn-res     (post :transact txn-req)
-          _           (assert (= 200 (:status txn-res)))
-          query-req   {:body
-                       (pr-str
-                        {:ledger ledger-name
-                         :query  {:commit-details true
-                                  :t              {:at :latest}}})
-                       :headers edn-headers}
-          query-res   (post :history query-req)]
+    (let [ledger-name   "history-query-edn-test"
+          edn-headers   {"Content-Type" "application/edn"
+                         "Accept"       "application/edn"}
+          txn-req       {:body
+                         (pr-str
+                          {:ledger ledger-name
+                           :txn    [{:id      :ex/query-test
+                                     :type    :schema/Test
+                                     :ex/name "query-test"}]})
+                         :headers edn-headers}
+          txn-res       (post :create txn-req)
+          _             (assert (= 201 (:status txn-res)))
+          txn2-req      {:body
+                         (pr-str
+                          {:ledger ledger-name
+                           :txn    [{:id           :ex/query-test
+                                     :ex/test-type "integration"}]})
+                         :headers edn-headers}
+          txn2-res      (post :transact txn2-req)
+          _             (assert (= 200 (:status txn2-res)))
+          query-req     {:body
+                         (pr-str
+                          {:ledger ledger-name
+                           :query  {:commit-details true
+                                    :t              {:from 1}}})
+                         :headers edn-headers}
+          query-res     (post :history query-req)
+          query-results (-> query-res :body edn/read-string)]
       (is (= 200 (:status query-res))
           (str "History query response was: " (pr-str query-res)))
-      (is (= [{:f/commit
-               {:f/data
-                {:f/assert
-                 [{:ex/name  "query-test"
-                   :id       :ex/query-test
-                   :rdf/type [:schema/Test]}]
-                 :f/retract []}}}]
-             (-> query-res :body edn/read-string))))))
+      (let [history-expectations
+            {[:id]                 #(re-matches commit-id-regex %)
+             [:f/address]          #(re-matches mem-addr-regex %)
+             [:f/alias]            #(= % ledger-name)
+             [:f/branch]           #(= % "main")
+             [:f/defaultContext]   #(re-matches context-id-regex (:id %))
+             [:f/previous]         #(or (nil? %)
+                                        (re-matches commit-id-regex (:id %)))
+             [:f/time]             pos-int?
+             [:f/v]                nat-int?
+             [:f/data :f/address]  #(re-matches mem-addr-regex %)
+             [:f/data :f/assert]   #(and (vector? %) (every? map? %))
+             [:f/data :f/retract]  #(and (vector? %) (every? map? %))
+             [:f/data :f/flakes]   pos-int?
+             [:f/data :f/size]     pos-int?
+             [:f/data :f/t]        pos-int?
+             [:f/data :f/previous] #(or (nil? %)
+                                        (re-matches db-id-regex (:id %)))}]
+        (is (every? #(every? (fn [[kp valid?]]
+                               (let [actual (get-in % kp)]
+                                 (or
+                                  (valid? actual)
+                                  (println "invalid:" (pr-str actual)))))
+                             history-expectations)
+                    (map :f/commit query-results)))))))
 
 (deftest ^:integration ^:json policy-opts-json-test
   (testing "policy-enforcing opts are correctly handled"


### PR DESCRIPTION
Some fixes have recently landed on db (notably commit-details now works w/ loaded ledgers) so this updates the db commit we're pointed at to latest main HEAD as of the opening of this PR, updates test expectations, and removes some more vestigial request transformation code.