### PR TITLE
Feature/credentials in api

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.11.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "1c48a078af44ce4ab61f39410169d8c120300c56"}}
+                                         :git/sha "cb2d133ae408c475fdc79ca1625a1d0e6bb2c8d2"}}
 
  :aliases
  {:dev

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -140,7 +140,7 @@
    :responses  {200 {:body QueryResponse}
                 400 {:body ErrorResponse}
                 500 {:body ErrorResponse}}
-   :handler    ledger/query})
+   :handler    #'ledger/query})
 
 (def multi-query-endpoint
   {:summary    "Endpoint for submitting multi-queries"
@@ -148,7 +148,7 @@
    :responses  {200 {:body MultiQueryResponse}
                 400 {:body ErrorResponse}
                 500 {:body ErrorResponse}}
-   :handler    ledger/multi-query})
+   :handler    #'ledger/multi-query})
 
 (def history-endpoint
   {:summary    "Endpoint for submitting history queries"
@@ -156,7 +156,7 @@
    :responses  {200 {:body HistoryQueryResponse}
                 400 {:body ErrorResponse}
                 500 {:body ErrorResponse}}
-   :handler    ledger/history})
+   :handler    #'ledger/history})
 
 (defn wrap-assoc-conn
   [conn handler]
@@ -271,14 +271,14 @@
                    :responses  {201 {:body CreateResponseBody}
                                 400 {:body ErrorResponse}
                                 500 {:body ErrorResponse}}
-                   :handler    ledger/create}}]
+                   :handler    #'ledger/create}}]
           ["/transact"
            {:post {:summary    "Endpoint for submitting transactions"
                    :parameters {:body TransactRequestBody}
                    :responses {200 {:body TransactResponseBody}
                                400 {:body ErrorResponse}
                                500 {:body ErrorResponse}}
-                   :handler ledger/transact}}]
+                   :handler #'ledger/transact}}]
           ["/query"
            {:get  query-endpoint
             :post query-endpoint}]

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -47,9 +47,8 @@
 (defn txn-body->opts
   [{:keys [defaultContext opts] :as _body} content-type]
   (let [content-type* (header->content-type content-type)]
-    (cond-> opts
-            true (assoc :context-type (content-type->context-type content-type*))
-            defaultContext (assoc :defaultContext defaultContext))))
+    (cond-> (assoc opts :context-type (content-type->context-type content-type*))
+      defaultContext (assoc :defaultContext defaultContext))))
 
 (defn query-body->opts
   [{:keys [query] :as _body} content-type]
@@ -64,7 +63,7 @@
 
 (def create
   (error-catching-handler
-    (fn [{:keys [fluree/conn content-type] {{:keys [ledger txn] :as body} :body} :parameters}]
+    (fn [{:keys [fluree/conn content-type credential/issuer] {{:keys [ledger txn] :as body} :body} :parameters}]
       (let [ledger-exists? (deref! (fluree/exists? conn ledger))]
         (log/debug "Ledger" ledger "exists?" ledger-exists?)
         (if ledger-exists?
@@ -72,23 +71,22 @@
             (throw (ex-info err-message
                             {:response {:status 409
                                         :body   {:error err-message}}})))
-          (do
-            (log/info "Creating ledger" ledger)
-            (let [opts    (txn-body->opts body content-type)
-                  _       (log/debug "create opts:" opts)
-                  ledger* (deref! (fluree/create conn ledger opts))
-                  db      (-> ledger*
-                              fluree/db
-                              (fluree/stage txn opts)
-                              deref!
-                              (->> (fluree/commit! ledger*))
-                              deref!)]
-              {:status 201
-               :body   (ledger-summary db)})))))))
+          (let [opts    (cond-> (txn-body->opts body content-type)
+                          issuer (assoc :issuer issuer))
+                _       (log/info "Creating ledger" ledger opts)
+                ledger* (deref! (fluree/create conn ledger opts))
+                db      (-> ledger*
+                            fluree/db
+                            (fluree/stage txn opts)
+                            deref!
+                            (->> (fluree/commit! ledger*))
+                            deref!)]
+            {:status 201
+             :body   (ledger-summary db)}))))))
 
 (def transact
   (error-catching-handler
-    (fn [{:keys [fluree/conn content-type] {{:keys [ledger txn] :as body} :body} :parameters}]
+    (fn [{:keys [fluree/conn content-type credential/issuer] {{:keys [ledger txn] :as body} :body} :parameters}]
       (println "\nTransacting to" ledger ":" (pr-str txn))
       (let [ledger  (if (deref! (fluree/exists? conn ledger))
                       (do
@@ -96,7 +94,8 @@
                                    "exists; loading it")
                         (deref! (fluree/load conn ledger)))
                       (throw (ex-info "Ledger does not exist" {:ledger ledger})))
-            opts    (txn-body->opts body content-type)
+            opts    (cond-> (txn-body->opts body content-type)
+                      issuer (assoc :issuer issuer))
             ;; TODO: Add a transact! fn to f.d.json-ld.api that stages and commits in one step
             db      (-> ledger
                         fluree/db
@@ -109,29 +108,35 @@
 
 (def query
   (error-catching-handler
-    (fn [{:keys [fluree/conn content-type] {{:keys [ledger query] :as body} :body} :parameters}]
+    (fn [{:keys [fluree/conn content-type credential/issuer] {{:keys [ledger query] :as body} :body} :parameters}]
       (log/debug "query handler received body:" body)
       (let [db     (->> ledger (fluree/load conn) deref! fluree/db)
-            query* (assoc query :opts (query-body->opts body content-type))]
+            opts (cond-> (query-body->opts body content-type)
+                   issuer (assoc :issuer issuer))
+            query* (assoc query :opts opts)]
         (log/debug "query - Querying ledger" ledger "-" query*)
         {:status 200
          :body   (deref! (fluree/query db query*))}))))
 
 (def multi-query
   (error-catching-handler
-   (fn [{:keys [fluree/conn content-type] {{:keys [ledger query] :as body} :body} :parameters}]
+   (fn [{:keys [fluree/conn content-type credential/issuer] {{:keys [ledger query] :as body} :body} :parameters}]
      (let [db     (->> ledger (fluree/load conn) deref! fluree/db)
-           query* (assoc query :opts (query-body->opts body content-type))]
+           opts (cond-> (query-body->opts body content-type)
+                  issuer (assoc :issuer issuer))
+           query* (assoc query :opts opts)]
        (log/debug "multi-query - Querying ledger" ledger "-" query)
        {:status 200
         :body   (deref! (fluree/multi-query db query*))}))))
 
 (def history
   (error-catching-handler
-    (fn [{:keys [fluree/conn content-type] {{:keys [ledger query] :as body} :body} :parameters}]
+    (fn [{:keys [fluree/conn content-type credential/issuer] {{:keys [ledger query] :as body} :body} :parameters}]
       (log/debug "history handler got query:" query)
       (let [ledger* (->> ledger (fluree/load conn) deref!)
-            query*  (assoc query :opts (query-body->opts body content-type))]
+            opts (cond-> (query-body->opts body content-type)
+                   issuer (assoc :issuer issuer))
+            query*  (assoc query :opts opts)]
         (log/debug "history - Querying ledger" ledger "-" query*)
         (let [results (deref! (fluree/history ledger* query*))]
           (log/debug "history - query results:" results)

--- a/test/fluree/http_api/integration/credential_test.clj
+++ b/test/fluree/http_api/integration/credential_test.clj
@@ -1,0 +1,114 @@
+(ns fluree.http-api.integration.credential-test
+  (:require [clojure.edn :as edn]
+            [clojure.core.async :as async]
+            [clojure.test :as test :refer [deftest testing is]]
+            [fluree.db.json-ld.credential :as cred]
+            [fluree.http-api.integration.test-system :refer :all :as test-utils]
+            [jsonista.core :as json]))
+
+(test/use-fixtures :once test-utils/run-test-server)
+
+(deftest ^:integration  credential-test
+  (let [ledger-name "credential-test"]
+    (testing "create"
+      (let [create-req  (async/<!! (cred/generate
+                                     {"ledger" ledger-name
+                                      "txn"    [{"id"      "ex:cred-test"
+                                                 "type"    "schema:Test"
+                                                 "ex:name" "cred test"}]}
+                                     (:private test-utils/auth)))
+            create-res  (test-utils/post :create {:body    (json/write-value-as-string create-req)
+                                                  :headers test-utils/json-headers})]
+        (is (= 201 (:status create-res)))
+        (is (= {"address" "fluree:memory://credential-test/main/head",
+                "t"       1,
+                "alias"   "credential-test"}
+               (-> create-res :body json/read-value)))))
+    (testing "transact"
+      (let [txn-req (async/<!! (cred/generate
+                                 {"ledger" ledger-name
+                                  "txn"    [{"id"      "ex:cred-test"
+                                             "type"    "schema:Test"
+                                             "ex:name" "cred test"
+                                             "ex:foo"  1}]}
+                                 (:private test-utils/auth)))
+            txn-res (test-utils/post :transact {:body (json/write-value-as-string txn-req)
+                                                :headers test-utils/json-headers})]
+        (is (= 200 (:status txn-res)))
+        (is (= {"address" "fluree:memory://credential-test/main/head",
+                "t"       2,
+                "alias"   "credential-test"}
+               (-> txn-res :body json/read-value)))))
+    (testing "query"
+      (let [query-req (async/<!! (cred/generate {"ledger" ledger-name
+                                                 "query"  {"select" {"?t" ["*"]}
+                                                           "where"  [["?t" "type" "schema:Test"]]}}
+                                                (:private test-utils/auth)))
+            query-res (test-utils/post :query {:body    (json/write-value-as-string query-req)
+                                               :headers test-utils/json-headers})]
+        (is (= 200 (:status query-res)))
+        (is (= [{"ex:name"  "cred test",
+                 "ex:foo"   1,
+                 "id"       "ex:cred-test",
+                 "rdf:type" ["schema:Test"]}]
+               (-> query-res :body json/read-value)))))
+    (testing "multi-query"
+      (let [multi-query-req (async/<!! (cred/generate {"ledger" ledger-name
+                                                       "query"  {"test" {"select" {"?t" ["*"]}
+                                                                         "where"  [["?t" "type" "schema:Test"]]}
+                                                                 "subj" {"select" {"?s" ["*"]}
+                                                                         "where"  [["?s" "@id" "ex:cred-test"]]}}}
+                                                      (:private test-utils/auth)))
+            multi-query-res (test-utils/post :multi-query {:body    (json/write-value-as-string multi-query-req)
+                                                           :headers test-utils/json-headers})]
+        (is (= 200 (:status multi-query-res)))
+        (is (= {"subj"
+                [{"ex:name"  "cred test",
+                  "ex:foo"   1,
+                  "id"       "ex:cred-test",
+                  "rdf:type" ["schema:Test"]}],
+                "test"
+                [{"ex:name"  "cred test",
+                  "ex:foo"   1,
+                  "id"       "ex:cred-test",
+                  "rdf:type" ["schema:Test"]}]}
+               (-> multi-query-res :body json/read-value)))))
+    (testing "history"
+      (let [history-req (async/<!! (cred/generate {"ledger" ledger-name
+                                                   "query"  {"history" "ex:cred-test"
+                                                             "t"       {"from" 1}}}
+                                                  (:private test-utils/auth)))
+
+            history-res (test-utils/post :history {:body    (json/write-value-as-string history-req)
+                                                   :headers test-utils/json-headers})]
+        (is (= 200 (:status history-res)))
+        (is (= [{"f:retract" [],
+                 "f:assert"
+                 [{"ex:name" "cred test",
+                   "id" "ex:cred-test",
+                   "rdf:type" ["schema:Test"]}],
+                 "f:t" 1}
+                {"f:retract" [{"ex:name" "cred test", "id" "ex:cred-test"}],
+                 "f:assert"
+                 [{"ex:name" "cred test",
+                   "ex:foo" 1,
+                   "id" "ex:cred-test",
+                   "rdf:type" ["schema:Test"]}],
+                 "f:t" 2}]
+               (-> history-res :body json/read-value)))))
+
+    (testing "invalid credential"
+      (let [invalid-tx  (-> (async/<!! (cred/generate
+                                         {"@context" {"ledger" "http://flur.ee/ns/ledger"
+                                                      "txn" "http://flur.ee/ns/txn"}
+                                          "ledger" "credential-test"
+                                          "txn"    {"@id" "ex:cred-test"
+                                                    "ex:KEY" "VALUE"}}
+                                         (:private test-utils/auth)))
+                            (assoc-in ["credentialSubject" "txn" "ex:KEY"] "ALTEREDVALUE"))
+
+            invalid-res (test-utils/post :transact {:body    (json/write-value-as-string invalid-tx)
+                                                    :headers test-utils/json-headers})]
+        (is (= 400 (:status invalid-res)))
+        (is (= {"error" "Invalid credential"}
+               (-> invalid-res :body json/read-value)))))))

--- a/test/fluree/http_api/integration/test_system.clj
+++ b/test/fluree/http_api/integration/test_system.clj
@@ -65,3 +65,8 @@
     (if (= 201 (:status res))
       (get-in res [:body :alias])
       (throw (ex-info "Error creating random ledger" res)))))
+
+(def auth
+  {:id "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh"
+   :public "03b160698617e3b4cd621afd96c0591e33824cb9753ab2f1dace567884b4e242b0"
+   :private "509553eece84d5a410f1012e8e19e84e938f226aa3ad144e2d12f36df0f51c1e"})


### PR DESCRIPTION
This provides the http api the ability to accept credential wrapped requests. 

https://github.com/fluree/core/issues/2

It creates a new middleware wrapper that checks to see if the request body is a verifiable credential. If it is, it will verify the credential and pass along the issuer along with the subject if the signature is valid.

This is not actually very useful yet, as most of our requests are not valid json-ld. This is a problem because the credential verification method canonicalizes the credential subject, then hashes it, then signs the hash. If the credential subject is not valid json-ld, it canonicalizes to an empty string. This means you can have a valid signature even if the credential is tampered with. 

Until we have valid json-ld credential subjects, we shouldn't consider a valid credential a very important signal of trustworthiness. This PR just lays the groundwork for that day.