### PR TITLE
Feature: default context read & update

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.11.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "32edebd490bbf1799be0020d9315ea46c9a84275"}}
+                                         :git/sha "81fa297c99fcdbb2be2801da02276530b43762c7"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -3,8 +3,8 @@
          org.clojure/core.async         {:mvn/version "1.6.673"}
          club.donutpower/system         {:mvn/version "0.0.165"}
          aero/aero                      {:mvn/version "1.1.6"}
-         info.sunng/ring-jetty9-adapter {:mvn/version "0.21.0"}
-         ch.qos.logback/logback-classic {:mvn/version "1.4.7"}
+         info.sunng/ring-jetty9-adapter {:mvn/version "0.22.0"}
+         ch.qos.logback/logback-classic {:mvn/version "1.4.8"}
          org.slf4j/slf4j-api            {:mvn/version "2.0.7"}
          metosin/reitit                 {:mvn/version "0.6.0"}
          metosin/muuntaja               {:mvn/version "0.6.8"}
@@ -27,7 +27,7 @@
 
   :test
   {:extra-paths ["test"]
-   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.83.1314"}
+   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.85.1342"}
                  clj-http/clj-http   {:mvn/version "3.12.3"}}
    :exec-fn     kaocha.runner/exec-fn
    :exec-args   {}}

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -120,6 +120,14 @@
 (def HistoryQueryResponse
   (m/schema [:sequential map?]))
 
+(def DefaultContextRequestBody
+  (m/schema [:and
+             [:map-of :keyword :any]
+             [:map
+              [:ledger LedgerAlias]]]))
+
+(def DefaultContextResponseBody Context)
+
 (def ErrorResponse
   [:or :string map?])
 
@@ -302,10 +310,10 @@
           ["/transact"
            {:post {:summary    "Endpoint for submitting transactions"
                    :parameters {:body TransactRequestBody}
-                   :responses {200 {:body TransactResponseBody}
-                               400 {:body ErrorResponse}
-                               500 {:body ErrorResponse}}
-                   :handler #'ledger/transact}}]
+                   :responses  {200 {:body TransactResponseBody}
+                                400 {:body ErrorResponse}
+                                500 {:body ErrorResponse}}
+                   :handler    #'ledger/transact}}]
           ["/query"
            {:get  query-endpoint
             :post query-endpoint}]
@@ -314,7 +322,14 @@
             :post multi-query-endpoint}]
           ["/history"
            {:get  history-endpoint
-            :post history-endpoint}]]]
+            :post history-endpoint}]
+          ["/defaultContext"
+           {:get  {:summary    "Endpoint for retrieving default contexts"
+                   :parameters {:body DefaultContextRequestBody}
+                   :responses  {200 {:body DefaultContextResponseBody}
+                                400 {:body ErrorResponse}
+                                500 {:body ErrorResponse}}
+                   :handler    #'ledger/default-context}}]]]
         {:data {:coercion   (reitit.coercion.malli/create
                              {:strip-extra-keys false})
                 :muuntaja   (muuntaja/create

--- a/test/fluree/http_api/integration/basic_query_test.clj
+++ b/test/fluree/http_api/integration/basic_query_test.clj
@@ -16,7 +16,7 @@
                                     "type"    "schema:Test"
                                     "ex:name" "query-test"}]})
                        :headers json-headers}
-          txn-res     (post :transact txn-req)
+          txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
           query-req   {:body
                        (json/write-value-as-string
@@ -24,7 +24,7 @@
                          "query"  {"select" '{?t ["*"]}
                                    "where"  '[[?t "type" "schema:Test"]]}})
                        :headers json-headers}
-          query-res   (post :query query-req)]
+          query-res   (api-post :query query-req)]
       (is (= 200 (:status query-res)))
       (is (= [{"id"       "ex:query-test"
                "rdf:type" ["schema:Test"]
@@ -43,7 +43,7 @@
                                     "type"     "schema:Person"
                                     "ex:fname" "Wes"}]})
                        :headers json-headers}
-          txn-res     (post :transact txn-req)
+          txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
           query-req   {:body
                        (json/write-value-as-string
@@ -53,7 +53,7 @@
                                                [[[?s "ex:name" ?n]]
                                                 [[?s "ex:fname" ?n]]]}]}})
                        :headers json-headers}
-          query-res   (post :query query-req)]
+          query-res   (api-post :query query-req)]
       (is (= 200 (:status query-res)))
       (is (= ["query-test" "Wes"]
              (-> query-res :body json/read-value)))))
@@ -79,7 +79,7 @@
                                     "ex:friend"    [{"id" "ex:brian"}
                                                     {"id" "ex:alice"}]}]})
                        :headers json-headers}
-          txn-res     (post :transact txn-req)
+          txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
           query       {"ledger" ledger-name
                        "query"  '{"select" [?name ?favColor]
@@ -89,7 +89,7 @@
           query-req   {:body
                        (json/write-value-as-string query)
                        :headers json-headers}
-          query-res   (post :query query-req)]
+          query-res   (api-post :query query-req)]
       (is (= 200 (:status query-res))
           (str "Response was: " (pr-str query-res)))
       (is (= [["Cam" nil]
@@ -107,7 +107,7 @@
                                     "type"    "schema:Test"
                                     "ex:name" "query-test"}]})
                        :headers json-headers}
-          txn-res     (post :transact txn-req)
+          txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
           query-req   {:body
                        (json/write-value-as-string
@@ -115,7 +115,7 @@
                          "query"  {"selectOne" '{?t ["*"]}
                                    "where"     '[[?t "type" "schema:Test"]]}})
                        :headers json-headers}
-          query-res   (post :query query-req)]
+          query-res   (api-post :query query-req)]
       (is (= 200 (:status query-res)))
       (is (= {"id"       "ex:query-test"
               "rdf:type" ["schema:Test"]
@@ -174,7 +174,7 @@
                                     {"@type"  "@id"
                                      "@value" "ex:betty"}]}]}}})}
 
-          txn-res     (post :transact txn-req)
+          txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
           query-req   {:body
                        (json/write-value-as-string
@@ -185,7 +185,7 @@
                                     ["?s" "schema:age" "?age"]
                                     {"bind" {"?canVote" "(>= ?age 18)"}}]}})
                        :headers json-headers}
-          query-res   (post :query query-req)]
+          query-res   (api-post :query query-req)]
       (is (= 200 (:status query-res))
           (str "Query response was: " (pr-str query-res)))
       (is (= [["Freddy" 4 false]
@@ -203,14 +203,14 @@
                                           :type    :schema/Test
                                           :ex/name "query-test"}]})
                        :headers edn-headers}
-          txn-res     (post :transact txn-req)
+          txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
           query-req   {:body
                        (pr-str {:ledger ledger-name
                                 :query  {:select '{?t [:*]}
                                          :where  '[[?t :type :schema/Test]]}})
                        :headers edn-headers}
-          query-res   (post :query query-req)]
+          query-res   (api-post :query query-req)]
       (is (= 200 (:status query-res))
           (str "Query response was:" (pr-str query-res)))
       (is (= [{:id       :ex/query-test

--- a/test/fluree/http_api/integration/basic_query_test.clj
+++ b/test/fluree/http_api/integration/basic_query_test.clj
@@ -183,15 +183,16 @@
                          {"select" ["?name" "?age" "?canVote"]
                           "where"  [["?s" "schema:name" "?name"]
                                     ["?s" "schema:age" "?age"]
-                                    {"bind" {"?canVote" "(>= ?age 18)"}}]}})
+                                    {"bind" {"?canVote" "(>= ?age 18)"}}]
+                          "orderBy" "?name"}})
                        :headers json-headers}
           query-res   (api-post :query query-req)]
       (is (= 200 (:status query-res))
           (str "Query response was: " (pr-str query-res)))
-      (is (= [["Freddy" 4 false]
-              ["Leticia" 2 false]
+      (is (= [["Andrew Johnson" 35 true]
               ["Betty" 82 true]
-              ["Andrew Johnson" 35 true]]
+              ["Freddy" 4 false]
+              ["Leticia" 2 false]]
              (-> query-res :body json/read-value))))))
 
 (deftest ^:integration ^:edn query-edn-test

--- a/test/fluree/http_api/integration/basic_transaction_test.clj
+++ b/test/fluree/http_api/integration/basic_transaction_test.clj
@@ -16,7 +16,7 @@
                         "txn"            [{"id"      "ex:create-test"
                                            "type"    "foo:test"
                                            "ex:name" "create-endpoint-test"}]})
-          res         (post :create {:body req :headers json-headers})]
+          res         (api-post :create {:body req :headers json-headers})]
       (is (= 201 (:status res)))
       (is (= {"address" address
               "alias"   ledger-name
@@ -32,7 +32,7 @@
                                :txn            [{:id      :ex/create-test
                                                  :type    :foo/test
                                                  :ex/name "create-endpoint-test"}]})
-          res         (post :create {:body req :headers edn-headers})]
+          res         (api-post :create {:body req :headers edn-headers})]
       (is (= 201 (:status res)))
       (is (= {:address address
               :alias   ledger-name
@@ -46,9 +46,9 @@
                                :txn            [{:id      :ex/create-test
                                                  :type    :foo/test
                                                  :ex/name "create-endpoint-test"}]})
-          res-success (post :create {:body req :headers edn-headers})
+          res-success (api-post :create {:body req :headers edn-headers})
           _           (assert (= 201 (:status res-success)))
-          res-fail    (post :create {:body req :headers edn-headers})]
+          res-fail    (api-post :create {:body req :headers edn-headers})]
       (is (= 409 (:status res-fail))))))
 
 (deftest ^:integration ^:json transaction-json-test
@@ -60,7 +60,7 @@
                         "txn"    {"id"      "ex:transaction-test"
                                   "type"    "schema:Test"
                                   "ex:name" "transact-endpoint-json-test"}})
-          res         (post :transact {:body req :headers json-headers})]
+          res         (api-post :transact {:body req :headers json-headers})]
       (is (= 200 (:status res)))
       (is (= {"address" address, "alias" ledger-name, "t" 2}
              (-> res :body json/read-value))))))
@@ -74,7 +74,7 @@
                         :txn    [{:id      :ex/transaction-test
                                   :type    :schema/Test
                                   :ex/name "transact-endpoint-edn-test"}]})
-          res         (post :transact {:body req :headers edn-headers})]
+          res         (api-post :transact {:body req :headers edn-headers})]
       (is (= 200 (:status res)))
       (is (= {:address address, :alias ledger-name, :t 2}
              (-> res :body edn/read-string))))))

--- a/test/fluree/http_api/integration/credential_test.clj
+++ b/test/fluree/http_api/integration/credential_test.clj
@@ -36,8 +36,8 @@
                                     "f:targetNode" {"id" "f:allNodes"}
                                     "f:allow" [{"f:targetRole" {"id" "role:root"}
                                                 "f:action" [{"id" "f:view"} {"id" "f:modify"}]}]}]}
-            create-res  (test-utils/post :create {:body    (json/write-value-as-string create-req)
-                                                  :headers test-utils/json-headers})]
+            create-res  (test-utils/api-post :create {:body (json/write-value-as-string create-req)
+                                                      :headers  test-utils/json-headers})]
         (is (= 201 (:status create-res)))
         (is (= {"address" "fluree:memory://credential-test/main/head",
                 "t"       1,
@@ -51,8 +51,8 @@
                                              "ex:name" "cred test"
                                              "ex:foo"  1}]}
                                  (:private test-utils/auth)))
-            txn-res (test-utils/post :transact {:body (json/write-value-as-string txn-req)
-                                                :headers test-utils/json-headers})]
+            txn-res (test-utils/api-post :transact {:body (json/write-value-as-string txn-req)
+                                                    :headers  test-utils/json-headers})]
         (is (= 200 (:status txn-res)))
         (is (= {"address" "fluree:memory://credential-test/main/head",
                 "t"       2,
@@ -63,8 +63,8 @@
                                                  "query"  {"select" {"?t" ["*"]}
                                                            "where"  [["?t" "type" "schema:Test"]]}}
                                                 (:private test-utils/auth)))
-            query-res (test-utils/post :query {:body    (json/write-value-as-string query-req)
-                                               :headers test-utils/json-headers})]
+            query-res (test-utils/api-post :query {:body (json/write-value-as-string query-req)
+                                                   :headers  test-utils/json-headers})]
         (is (= 200 (:status query-res)))
         (is (= [{"ex:name"  "cred test",
                  "ex:foo"   1,
@@ -78,8 +78,8 @@
                                                                  "subj" {"select" {"?s" ["*"]}
                                                                          "where"  [["?s" "@id" "ex:cred-test"]]}}}
                                                       (:private test-utils/auth)))
-            multi-query-res (test-utils/post :multi-query {:body    (json/write-value-as-string multi-query-req)
-                                                           :headers test-utils/json-headers})]
+            multi-query-res (test-utils/api-post :multi-query {:body (json/write-value-as-string multi-query-req)
+                                                               :headers  test-utils/json-headers})]
         (is (= 200 (:status multi-query-res)))
         (is (= {"subj"
                 [{"ex:name"  "cred test",
@@ -98,8 +98,8 @@
                                                              "t"       {"from" 1}}}
                                                   (:private test-utils/auth)))
 
-            history-res (test-utils/post :history {:body    (json/write-value-as-string history-req)
-                                                   :headers test-utils/json-headers})]
+            history-res (test-utils/api-post :history {:body (json/write-value-as-string history-req)
+                                                       :headers  test-utils/json-headers})]
         (is (= 200 (:status history-res)))
         (is (= [{"f:retract" [],
                  "f:assert"
@@ -120,8 +120,8 @@
                                          (:private test-utils/auth)))
                             (assoc-in ["credentialSubject" "txn" "ex:KEY"] "ALTEREDVALUE"))
 
-            invalid-res (test-utils/post :transact {:body    (json/write-value-as-string invalid-tx)
-                                                    :headers test-utils/json-headers})]
+            invalid-res (test-utils/api-post :transact {:body (json/write-value-as-string invalid-tx)
+                                                        :headers  test-utils/json-headers})]
         (is (= 400 (:status invalid-res)))
         (is (= {"error" "Invalid credential"}
                (-> invalid-res :body json/read-value)))))))

--- a/test/fluree/http_api/integration/default_context_test.clj
+++ b/test/fluree/http_api/integration/default_context_test.clj
@@ -1,0 +1,55 @@
+(ns fluree.http-api.integration.default-context-test
+  (:require [clojure.test :refer :all]
+            [fluree.http-api.integration.test-system :refer :all]
+            [jsonista.core :as json]))
+
+(use-fixtures :once run-test-server)
+
+(deftest ^:integration get-default-context-test
+  (testing "can retrieve default context for a ledger"
+    (let [ledger-name         (create-rand-ledger "get-default-context-test")
+          default-context-req {:body    (json/write-value-as-string
+                                         {:ledger ledger-name})
+                               :headers json-headers}
+          default-context-res (api-get :defaultContext default-context-req)]
+      (is (= 200 (:status default-context-res)))
+      (is (= {"ex"     "http://example.com/",
+              "f"      "https://ns.flur.ee/ledger#",
+              "foo"    "http://foobar.com/",
+              "id"     "@id",
+              "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+              "schema" "http://schema.org/",
+              "type"   "@type"}
+             (-> default-context-res :body json/read-value))))))
+
+(deftest ^:integration update-default-context-test
+  (testing "can update default context for a ledger"
+    (let [ledger-name          (create-rand-ledger "get-default-context-test")
+          default-context-req  {:body    (json/write-value-as-string
+                                          {:ledger ledger-name})
+                                :headers json-headers}
+          default-context-res  (api-get :defaultContext default-context-req)
+          default-context-0    (-> default-context-res :body json/read-value)
+          update-req           {:body    (json/write-value-as-string
+                                          {:ledger ledger-name
+                                           :txn [{:ex/name "Foo"}]
+                                           :opts
+                                           {:defaultContext
+                                            (-> default-context-0
+                                                (assoc "foo-new"
+                                                       (get default-context-0 "foo"))
+                                                (dissoc "foo"))}})
+                                :headers json-headers}
+          update-res           (api-post :transact update-req)
+          _                    (assert (= 200 (:status update-res)))
+          default-context-res' (api-get :defaultContext default-context-req)
+          default-context-1    (-> default-context-res' :body json/read-value)]
+      (is (= 200 (:status update-res)))
+      (is (= {"foo-new" "http://foobar.com/"
+              "ex"      "http://example.com/"
+              "f"       "https://ns.flur.ee/ledger#"
+              "id"      "@id"
+              "rdf"     "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+              "schema"  "http://schema.org/"
+              "type"    "@type"}
+             default-context-1)))))

--- a/test/fluree/http_api/integration/history_query_test.clj
+++ b/test/fluree/http_api/integration/history_query_test.clj
@@ -28,7 +28,7 @@
                                       "type"    "schema:Test"
                                       "ex:name" "query-test"}]})
                          :headers json-headers}
-          txn-res       (post :create txn-req)
+          txn-res       (api-post :create txn-req)
           _             (assert (= 201 (:status txn-res)))
           txn2-req      {:body
                          (json/write-value-as-string
@@ -36,7 +36,7 @@
                            "txn"    [{"id"           "ex:query-test"
                                       "ex:test-type" "integration"}]})
                          :headers json-headers}
-          txn2-res      (post :transact txn2-req)
+          txn2-res      (api-post :transact txn2-req)
           _             (assert (= 200 (:status txn2-res)))
           query-req     {:body
                          (json/write-value-as-string
@@ -44,7 +44,7 @@
                            "query"  {"commit-details" true
                                      "t"              {"at" "latest"}}})
                          :headers json-headers}
-          query-res     (post :history query-req)
+          query-res     (api-post :history query-req)
           query-results (-> query-res :body json/read-value)]
       (is (= 200 (:status query-res))
           (str "History query response was: " (pr-str query-res)))
@@ -85,7 +85,7 @@
                                      :type    :schema/Test
                                      :ex/name "query-test"}]})
                          :headers edn-headers}
-          txn-res       (post :create txn-req)
+          txn-res       (api-post :create txn-req)
           _             (assert (= 201 (:status txn-res)))
           txn2-req      {:body
                          (pr-str
@@ -93,7 +93,7 @@
                            :txn    [{:id           :ex/query-test
                                      :ex/test-type "integration"}]})
                          :headers edn-headers}
-          txn2-res      (post :transact txn2-req)
+          txn2-res      (api-post :transact txn2-req)
           _             (assert (= 200 (:status txn2-res)))
           query-req     {:body
                          (pr-str
@@ -101,7 +101,7 @@
                            :query  {:commit-details true
                                     :t              {:from 1}}})
                          :headers edn-headers}
-          query-res     (post :history query-req)
+          query-res     (api-post :history query-req)
           query-results (-> query-res :body edn/read-string)]
       (is (= 200 (:status query-res))
           (str "History query response was: " (pr-str query-res)))

--- a/test/fluree/http_api/integration/multi_query_test.clj
+++ b/test/fluree/http_api/integration/multi_query_test.clj
@@ -34,7 +34,7 @@
                                      "ex:User" {"id" "ex:wes"}
                                      "f:role"  {"id" "ex:userRole"}}]})
                         :headers json-headers}
-          txn-res      (post :transact txn-req)
+          txn-res      (api-post :transact txn-req)
           _            (assert (= 200 (:status txn-res)))
           query-req    {:body
                         (json/write-value-as-string
@@ -51,7 +51,7 @@
                                     "opts" {"role" "ex:userRole"
                                             "did"  wes-did}}})
                         :headers json-headers}
-          query-res    (post :multi-query query-req)]
+          query-res    (api-post :multi-query query-req)]
       (is (= 200 (:status query-res))
           (str "Query result was: " (pr-str query-res)))
       (is (= {"device" [{"ex:name"  "iPhone"

--- a/test/fluree/http_api/integration/policy_test.clj
+++ b/test/fluree/http_api/integration/policy_test.clj
@@ -37,7 +37,7 @@
                                     "ex:User" {"id" "ex:alice"}
                                     "f:role"  {"id" "ex:userRole"}}]})
                         :headers json-headers}
-          txn-res      (post :transact txn-req)
+          txn-res      (api-post :transact txn-req)
           _            (assert (= 200 (:status txn-res)))
           secret-query {"select" {"?s" ["*"]}
                         "where"  [["?s" "rdf:type" "ex:User"]]}
@@ -49,7 +49,7 @@
                                     :opts {"role" "ex:userRole"
                                            "did"  alice-did})})
                         :headers json-headers}
-          query-res    (post :query query-req)]
+          query-res    (api-post :query query-req)]
       (is (= 200 (:status query-res))
           (str "policy-enforced query response was: " (pr-str query-res)))
       (is (= [{"id" "ex:bob", "rdf:type" ["ex:User"]}
@@ -66,14 +66,14 @@
                          :opts   {"role" "ex:userRole"
                                   "did"  alice-did}})
                        :headers json-headers}
-            txn-res   (post :transact txn-req)
+            txn-res   (api-post :transact txn-req)
             _         (assert (= 200 (:status txn-res)))
             query-req {:body
                        (json/write-value-as-string
                         {:ledger ledger-name
                          :query  secret-query})
                        :headers json-headers}
-            query-res (post :query query-req)
+            query-res (api-post :query query-req)
             _         (assert (= 200 (:status query-res)))]
         (is (= [{"id"        "ex:bob",
                  "rdf:type"  ["ex:User"],
@@ -91,7 +91,7 @@
                          "opts"   {"role" "ex:userRole"
                                    "did"  alice-did}})
                        :headers json-headers}
-              txn-res (post :transact txn-req)]
+              txn-res (api-post :transact txn-req)]
           (is (not= 200 (:status txn-res))
               (str "transaction policy opts should have prevented modification, instead response was: " (pr-str txn-res)))
           (let [query-req {:body
@@ -102,7 +102,7 @@
                                        "opts"    {"role" "ex:userRole"
                                                   "did"  alice-did}}})
                            :headers json-headers}
-                query-res (post :history query-req)]
+                query-res (api-post :history query-req)]
             (is (= 200 (:status query-res))
                 (str "History query response was: " (pr-str query-res)))
             (is (= [{"id" "ex:bob", "rdf:type" ["ex:User"]}]
@@ -137,7 +137,7 @@
                                     :ex/User :ex/alice
                                     :f/role  :ex/userRole}]})
                         :headers edn-headers}
-          txn-res      (post :transact txn-req)
+          txn-res      (api-post :transact txn-req)
           _            (assert (= 200 (:status txn-res)))
           secret-query '{:select {?s [:*]}
                          :where  [[?s :rdf/type :ex/User]]}
@@ -149,7 +149,7 @@
                                     :opts {:role :ex/userRole
                                            :did  alice-did})})
                         :headers edn-headers}
-          query-res    (post :query query-req)]
+          query-res    (api-post :query query-req)]
       (is (= 200 (:status query-res))
           (str "policy-enforced query response was: " (pr-str query-res)))
       (is (= [{:id       :ex/bob
@@ -167,14 +167,14 @@
                          :opts   {:role :ex/userRole
                                   :did  alice-did}})
                        :headers edn-headers}
-            txn-res   (post :transact txn-req)
+            txn-res   (api-post :transact txn-req)
             _         (assert (= 200 (:status txn-res)))
             query-req {:body
                        (pr-str
                         {:ledger ledger-name
                          :query  secret-query})
                        :headers edn-headers}
-            query-res (post :query query-req)
+            query-res (api-post :query query-req)
             _         (assert (= 200 (:status query-res)))]
         (is (= [{:id        :ex/bob
                  :rdf/type  [:ex/User]
@@ -192,7 +192,7 @@
                          :opts   {:role :ex/userRole
                                   :did  alice-did}})
                        :headers edn-headers}
-              txn-res (post :transact txn-req)]
+              txn-res (api-post :transact txn-req)]
           (is (not= 200 (:status txn-res))
               (str "transaction policy opts should have prevented modification, instead response was:" (pr-str txn-res)))
           (let [query-req {:body
@@ -203,9 +203,9 @@
                                       :opts    {:role :ex/userRole
                                                 :did  alice-did}}})
                            :headers edn-headers}
-                query-res (post :history query-req)]
+                query-res (api-post :history query-req)]
             (is (= 200 (:status query-res))
                 (str "History query response was: " (pr-str query-res)))
             (is (= [{:id :ex/bob :rdf/type [:ex/User]}]
-                   (-> query-res :body edn/read-string first (get :f/assert)))
+                   (-> query-res :body edn/read-string first :f/assert))
                 "policy opts should have prevented seeing bob's secret")))))))

--- a/test/fluree/http_api/integration/test_system.clj
+++ b/test/fluree/http_api/integration/test_system.clj
@@ -47,8 +47,11 @@
 (defn api-url [endpoint]
   (str "http://localhost:" @api-port "/fluree/" (name endpoint)))
 
-(defn post [endpoint req]
+(defn api-post [endpoint req]
   (http/post (api-url endpoint) (assoc req :throw-exceptions false)))
+
+(defn api-get [endpoint req]
+  (http/get (api-url endpoint) (assoc req :throw-exceptions false)))
 
 (defn create-rand-ledger
   [name-root]
@@ -60,7 +63,7 @@
                                                :foo/name "create-endpoint-test"}]})
         headers     {"Content-Type" "application/edn"
                      "Accept"       "application/edn"}
-        res         (update (post :create {:body req :headers headers})
+        res         (update (api-post :create {:body req :headers headers})
                             :body edn/read-string)]
     (if (= 201 (:status res))
       (get-in res [:body :alias])


### PR DESCRIPTION
Closes #61 

Adds a new `GET /defaultContext` endpoint and a `:defaultContext` transact opt (optional) for setting the defaultContext. Currently db lib requires transacting some data to update the default context so it made sense to just add it to `/transact`. One day if db supports persisting a new default context without a data transaction we can enable e.g. `PUT /defaultContext`.