### PR TITLE
Feature: default context at t

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.11.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "cabd28b65a606ae7d17a9a3bf254b195d3f85252"}}
+                                         :git/sha "3197523e584b536cea0ae9983320405ef0e6e6b9"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.11.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "3197523e584b536cea0ae9983320405ef0e6e6b9"}}
+                                         :git/sha "a1f0e7be0bce2be4fd5ab2c1dc453d2b23c764de"}}
 
  :aliases
  {:dev

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -125,7 +125,8 @@
   (m/schema [:and
              [:map-of :keyword :any]
              [:map
-              [:ledger LedgerAlias]]]))
+              [:ledger LedgerAlias]
+              [:t {:optional true} TValue]]]))
 
 (def DefaultContextResponseBody Context)
 

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -68,6 +68,7 @@
              [:map
               [:ledger LedgerAlias]
               [:txn Transaction]
+              [:defaultContext {:optional true} Context]
               [:opts {:optional true} TransactOpts]]]))
 
 (def TransactResponseBody

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -100,8 +100,7 @@
             {:keys [defaultContext] :as opts} (txn-body->opts body content-type)
 
             opts    (cond-> opts
-                      did (assoc :did did)
-                      defaultContext (dissoc :defaultContext :default-context))
+                      did (assoc :did did))
             db      (fluree/db ledger)
             db      (if defaultContext
                       (do

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -154,10 +154,12 @@
 
 (def default-context
   (error-catching-handler
-   (fn [{:keys [fluree/conn] {{:keys [ledger] :as body} :body} :parameters}]
+   (fn [{:keys [fluree/conn] {{:keys [ledger t] :as body} :body} :parameters}]
      (log/debug "default-context handler got request:" body)
      (let [ledger* (->> ledger (fluree/load conn) deref!)]
-       (let [results (-> ledger* fluree/db fluree/default-context)]
+       (let [results (if t
+                       (-> ledger* (fluree/default-context-at-t t) deref)
+                       (-> ledger* fluree/db fluree/default-context))]
          (log/debug "default-context for ledger" (str ledger ":") results)
          {:status 200
           :body   results})))))

--- a/test/fluree/http_api/integration/default_context_test.clj
+++ b/test/fluree/http_api/integration/default_context_test.clj
@@ -20,7 +20,80 @@
               "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
               "schema" "http://schema.org/"
               "type"   "@type"}
-             (-> default-context-res :body json/read-value))))))
+             (-> default-context-res :body json/read-value)))))
+
+  (testing "can retrieve default context at a specific t"
+    (let [ledger-name          (create-rand-ledger "get-default-context-test")
+          default-context-req  {:body    (json/write-value-as-string
+                                          {:ledger ledger-name})
+                                :headers json-headers}
+          default-context-res  (api-get :defaultContext default-context-req)
+          default-context0     (-> default-context-res :body json/read-value)
+          default-context1     (-> default-context0
+                                   (assoc "ex-new"
+                                          "http://example.com/")
+                                   (dissoc "ex"))
+          default-context2     (-> default-context1
+                                   (assoc "foo-new"
+                                          "http://foobar.com/")
+                                   (dissoc "foo"))
+          txn0-req             {:body
+                                (json/write-value-as-string
+                                 {:ledger         ledger-name
+                                  :txn            [{"id"      "ex:nobody"
+                                                    "ex:name" "Nobody"}]
+                                  :defaultContext default-context1})
+                                :headers json-headers}
+          txn0-res             (api-post :transact txn0-req)
+          _                    (assert (= 200 (:status txn0-res)))
+          txn1-req             {:body
+                                (json/write-value-as-string
+                                 {:ledger         ledger-name
+                                  :txn            [{"id"      "ex:somebody"
+                                                    "ex:name" "Somebody"}]
+                                  :defaultContext default-context2})
+                                :headers json-headers}
+          txn1-res             (api-post :transact txn1-req)
+          _                    (assert (= 200 (:status txn1-res)))
+          default-context1-req {:body    (json/write-value-as-string
+                                          {:ledger ledger-name
+                                           :t      1})
+                                :headers json-headers}
+          default-context1-res (api-get :defaultContext default-context1-req)
+          default-context2-req {:body    (json/write-value-as-string
+                                          {:ledger ledger-name
+                                           :t      2})
+                                :headers json-headers}
+          default-context2-res (api-get :defaultContext default-context2-req)
+          default-context3-req {:body    (json/write-value-as-string
+                                          {:ledger ledger-name
+                                           :t      3})
+                                :headers json-headers}
+          default-context3-res (api-get :defaultContext default-context3-req)]
+      (is (= {"ex"     "http://example.com/"
+              "f"      "https://ns.flur.ee/ledger#"
+              "foo"    "http://foobar.com/"
+              "id"     "@id"
+              "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+              "schema" "http://schema.org/"
+              "type"   "@type"}
+             (-> default-context1-res :body json/read-value)))
+      (is (= {"ex-new" "http://example.com/"
+              "f"      "https://ns.flur.ee/ledger#"
+              "foo"    "http://foobar.com/"
+              "id"     "@id"
+              "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+              "schema" "http://schema.org/"
+              "type"   "@type"}
+             (-> default-context2-res :body json/read-value)))
+      (is (= {"ex-new"  "http://example.com/"
+              "f"       "https://ns.flur.ee/ledger#"
+              "foo-new" "http://foobar.com/"
+              "id"      "@id"
+              "rdf"     "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+              "schema"  "http://schema.org/"
+              "type"    "@type"}
+             (-> default-context3-res :body json/read-value))))))
 
 (deftest ^:integration update-default-context-test
   (testing "can update default context for a ledger"

--- a/test/fluree/http_api/integration/default_context_test.clj
+++ b/test/fluree/http_api/integration/default_context_test.clj
@@ -32,13 +32,12 @@
           default-context-0    (-> default-context-res :body json/read-value)
           update-req           {:body    (json/write-value-as-string
                                           {:ledger ledger-name
-                                           :txn [{:ex/name "Foo"}]
-                                           :opts
-                                           {:defaultContext
-                                            (-> default-context-0
-                                                (assoc "foo-new"
-                                                       (get default-context-0 "foo"))
-                                                (dissoc "foo"))}})
+                                           :txn    [{:ex/name "Foo"}]
+                                           :defaultContext
+                                           (-> default-context-0
+                                               (assoc "foo-new"
+                                                      (get default-context-0 "foo"))
+                                               (dissoc "foo"))})
                                 :headers json-headers}
           update-res           (api-post :transact update-req)
           _                    (assert (= 200 (:status update-res)))

--- a/test/fluree/http_api/integration/default_context_test.clj
+++ b/test/fluree/http_api/integration/default_context_test.clj
@@ -13,12 +13,12 @@
                                :headers json-headers}
           default-context-res (api-get :defaultContext default-context-req)]
       (is (= 200 (:status default-context-res)))
-      (is (= {"ex"     "http://example.com/",
-              "f"      "https://ns.flur.ee/ledger#",
-              "foo"    "http://foobar.com/",
-              "id"     "@id",
-              "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-              "schema" "http://schema.org/",
+      (is (= {"ex"     "http://example.com/"
+              "f"      "https://ns.flur.ee/ledger#"
+              "foo"    "http://foobar.com/"
+              "id"     "@id"
+              "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+              "schema" "http://schema.org/"
               "type"   "@type"}
              (-> default-context-res :body json/read-value))))))
 


### PR DESCRIPTION
Finishes https://github.com/fluree/core/issues/9

Commits 2d8d451cbcbaf7c3076cb3e091ca176f758aa26e & 01236dc98740008546d6a4bd9935f10c31670346 are unrelated cleanups. Let me know if the latter deserves its own PR for discussion.

I've exposed defaultContext at t via a new, optional `t` param to the `GET /defaultContext` endpoint. This needed a reify fix in db to work, so its pointed at that commit currently. db PR is here: https://github.com/fluree/db/pull/529