### PR TITLE
add docker-build, docker-run, and docker-push to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,15 @@ target/http-api-gateway-%.jar: $(SOURCES) $(RESOURCES)
 
 uberjar: target/http-api-gateway-%.jar
 
+docker-build:
+	docker buildx build --platform linux/amd64,linux/arm64 -t fluree/http-api-gateway:latest -t fluree/http-api-gateway:$(shell git rev-parse HEAD) --build-arg="PROFILE=prod" .
+
+docker-run:
+	docker run -p 58090:8090 -v `pwd`/data:/opt/fluree-http-api-gateway/data fluree/http-api-gateway
+
+docker-push:
+	docker buildx build --platform linux/amd64,linux/arm64 -t fluree/http-api-gateway:latest -t fluree/http-api-gateway:$(shell git rev-parse HEAD) --build-arg="PROFILE=prod" --push .
+
 .PHONY: test
 test:
 	clojure -X:test


### PR DESCRIPTION
This is mostly just a convenience to make it a bit easier to push updates to `fluree/http-api-gateway` image on DockerHub, particularly while no GitHub Action is in place for `http-api-gateway` and while we are iteratively pushing images out to the v3 Alpha community