### PR TITLE
Update to use new json-ld syntax in `/transact`

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.11.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "eae6f973ee1a3b50378292d3b468f8c70683c291"}}
+                                         :git/sha "6f54306143126a84a40c1578acd873c6d0410bbe"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.11.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "7c0ebd75420cf65cc0f2246d8153ce03315bd6fe"}}
+                                         :git/sha "e3f36f620ff26d1f1120a1d0fd9b765664005f40"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.11.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "6f54306143126a84a40c1578acd873c6d0410bbe"}}
+                                         :git/sha "03693ab3ba928556503818ccad8a9e43ac104b97"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.11.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "e7ef9696d53c52ddb8b54477d199487a3352b204"}}
+                                         :git/sha "eae6f973ee1a3b50378292d3b468f8c70683c291"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.11.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "03693ab3ba928556503818ccad8a9e43ac104b97"}}
+                                         :git/sha "b90a884a83bbe6bd33ad054801863a98f620ea65"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.11.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "b90a884a83bbe6bd33ad054801863a98f620ea65"}}
+                                         :git/sha "7c0ebd75420cf65cc0f2246d8153ce03315bd6fe"}}
 
  :aliases
  {:dev

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -63,14 +63,7 @@
               [:id {:optional true} DID]]]))
 
 (def TransactRequestBody
-  (m/schema [:map-of :any :any]
-            #_[:and
-               [:map-of :keyword :any]
-               [:map
-                [:ledger LedgerAlias]
-                [:txn Transaction]
-                [:defaultContext {:optional true} Context]
-                [:opts {:optional true} TransactOpts]]]))
+  (m/schema [:map-of :any :any]))
 
 (def TransactResponseBody
   (m/schema [:and

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -63,13 +63,14 @@
               [:id {:optional true} DID]]]))
 
 (def TransactRequestBody
-  (m/schema [:and
-             [:map-of :keyword :any]
-             [:map
-              [:ledger LedgerAlias]
-              [:txn Transaction]
-              [:defaultContext {:optional true} Context]
-              [:opts {:optional true} TransactOpts]]]))
+  (m/schema [:map-of :any :any]
+            #_[:and
+               [:map-of :keyword :any]
+               [:map
+                [:ledger LedgerAlias]
+                [:txn Transaction]
+                [:defaultContext {:optional true} Context]
+                [:opts {:optional true} TransactOpts]]]))
 
 (def TransactResponseBody
   (m/schema [:and

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -89,8 +89,7 @@
   (error-catching-handler
     (fn [{:keys [fluree/conn content-type credential/did]
           {:keys [body]} :parameters}]
-      (let [{:keys [defaultContext] :as opts} (txn-body->opts body content-type)
-            opts    (cond-> opts
+      (let [opts    (cond-> (txn-body->opts nil content-type)
                       did (assoc :did did))
             db      (-> (fluree/transact! conn body opts)
                         deref!)]

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -96,21 +96,10 @@
                                    "exists; loading it")
                         (deref! (fluree/load conn ledger)))
                       (throw (ex-info "Ledger does not exist" {:ledger ledger})))
-
             {:keys [defaultContext] :as opts} (txn-body->opts body content-type)
-
             opts    (cond-> opts
                       did (assoc :did did))
-            db      (fluree/db ledger)
-            db      (if defaultContext
-                      (do
-                        (log/trace "Updating default context to:" defaultContext)
-                        (fluree/update-default-context db defaultContext))
-                      db)
-            db      (-> db
-                        (fluree/stage txn opts)
-                        deref!
-                        (->> (fluree/commit! ledger))
+            db      (-> (fluree/transact! ledger txn opts)
                         deref!)]
         {:status 200
          :body   (ledger-summary db)}))))

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -88,18 +88,11 @@
 (def transact
   (error-catching-handler
     (fn [{:keys [fluree/conn content-type credential/did]
-          {{:keys [ledger txn] :as body} :body} :parameters}]
-      (println "\nTransacting to" ledger ":" (pr-str txn))
-      (let [ledger  (if (deref! (fluree/exists? conn ledger))
-                      (do
-                        (log/debug "transact - Ledger" ledger
-                                   "exists; loading it")
-                        (deref! (fluree/load conn ledger)))
-                      (throw (ex-info "Ledger does not exist" {:ledger ledger})))
-            {:keys [defaultContext] :as opts} (txn-body->opts body content-type)
+          {:keys [body]} :parameters}]
+      (let [{:keys [defaultContext] :as opts} (txn-body->opts body content-type)
             opts    (cond-> opts
                       did (assoc :did did))
-            db      (-> (fluree/transact! ledger txn opts)
+            db      (-> (fluree/transact! conn body opts)
                         deref!)]
         {:status 200
          :body   (ledger-summary db)}))))

--- a/test/fluree/http_api/integration/basic_query_test.clj
+++ b/test/fluree/http_api/integration/basic_query_test.clj
@@ -198,7 +198,9 @@
   (testing "can query a basic entity w/ EDN"
     (let [ledger-name (create-rand-ledger "query-endpoint-basic-entity-test")
           txn-req     {:body
-                       (pr-str {:id ledger-name
+                       (pr-str {:context {:id "@id"
+                                          :graph "@graph"}
+                                :id ledger-name
                                 :graph    [{:id      :ex/query-test
                                             :type    :schema/Test
                                             :ex/name "query-test"}]})

--- a/test/fluree/http_api/integration/basic_query_test.clj
+++ b/test/fluree/http_api/integration/basic_query_test.clj
@@ -26,9 +26,9 @@
                        :headers json-headers}
           query-res   (api-post :query query-req)]
       (is (= 200 (:status query-res)))
-      (is (= [{"id"       "ex:query-test"
-               "rdf:type" ["schema:Test"]
-               "ex:name"  "query-test"}]
+      (is (= [{"id"      "ex:query-test"
+               "type"    "schema:Test"
+               "ex:name" "query-test"}]
              (-> query-res :body json/read-value)))))
 
   (testing "union query works"
@@ -117,9 +117,9 @@
                        :headers json-headers}
           query-res   (api-post :query query-req)]
       (is (= 200 (:status query-res)))
-      (is (= {"id"       "ex:query-test"
-              "rdf:type" ["schema:Test"]
-              "ex:name"  "query-test"}
+      (is (= {"id"      "ex:query-test"
+              "type"    "schema:Test"
+              "ex:name" "query-test"}
              (-> query-res :body json/read-value)))))
 
   (testing "bind query works"
@@ -214,7 +214,7 @@
       (println "Q" query-req)
       (is (= 200 (:status query-res))
           (str "Query response was:" (pr-str query-res)))
-      (is (= [{:id       :ex/query-test
-               :rdf/type [:schema/Test]
-               :ex/name  "query-test"}]
+      (is (= [{:id      :ex/query-test
+               :type    :schema/Test
+               :ex/name "query-test"}]
              (-> query-res :body edn/read-string))))))

--- a/test/fluree/http_api/integration/basic_query_test.clj
+++ b/test/fluree/http_api/integration/basic_query_test.clj
@@ -11,10 +11,10 @@
     (let [ledger-name (create-rand-ledger "query-endpoint-basic-entity-test")
           txn-req     {:body
                        (json/write-value-as-string
-                        {"ledger" ledger-name
-                         "txn"    [{"id"      "ex:query-test"
-                                    "type"    "schema:Test"
-                                    "ex:name" "query-test"}]})
+                         {"@id" ledger-name
+                          "@graph"    [{"id"      "ex:query-test"
+                                        "type"    "schema:Test"
+                                        "ex:name" "query-test"}]})
                        :headers json-headers}
           txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
@@ -35,13 +35,13 @@
     (let [ledger-name (create-rand-ledger "query-endpoint-union-test")
           txn-req     {:body
                        (json/write-value-as-string
-                        {"ledger" ledger-name
-                         "txn"    [{"id"      "ex:query-test"
-                                    "type"    "schema:Test"
-                                    "ex:name" "query-test"}
-                                   {"id"       "ex:wes"
-                                    "type"     "schema:Person"
-                                    "ex:fname" "Wes"}]})
+                         {"@id" ledger-name
+                          "@graph"    [{"id"      "ex:query-test"
+                                        "type"    "schema:Test"
+                                        "ex:name" "query-test"}
+                                       {"id"       "ex:wes"
+                                        "type"     "schema:Person"
+                                        "ex:fname" "Wes"}]})
                        :headers json-headers}
           txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
@@ -62,22 +62,22 @@
     (let [ledger-name (create-rand-ledger "query-endpoint-optional-test")
           txn-req     {:body
                        (json/write-value-as-string
-                        {"ledger" ledger-name
-                         "txn"    [{"id"          "ex:brian",
-                                    "type"        "ex:User",
-                                    "schema:name" "Brian"
-                                    "ex:friend"   [{"id" "ex:alice"}]}
-                                   {"id"           "ex:alice",
-                                    "type"         "ex:User",
-                                    "ex:favColor"  "Green"
-                                    "schema:email" "alice@flur.ee"
-                                    "schema:name"  "Alice"}
-                                   {"id"           "ex:cam",
-                                    "type"         "ex:User",
-                                    "schema:name"  "Cam"
-                                    "schema:email" "cam@flur.ee"
-                                    "ex:friend"    [{"id" "ex:brian"}
-                                                    {"id" "ex:alice"}]}]})
+                         {"@id" ledger-name
+                          "@graph"    [{"id"          "ex:brian",
+                                        "type"        "ex:User",
+                                        "schema:name" "Brian"
+                                        "ex:friend"   [{"id" "ex:alice"}]}
+                                       {"id"           "ex:alice",
+                                        "type"         "ex:User",
+                                        "ex:favColor"  "Green"
+                                        "schema:email" "alice@flur.ee"
+                                        "schema:name"  "Alice"}
+                                       {"id"           "ex:cam",
+                                        "type"         "ex:User",
+                                        "schema:name"  "Cam"
+                                        "schema:email" "cam@flur.ee"
+                                        "ex:friend"    [{"id" "ex:brian"}
+                                                        {"id" "ex:alice"}]}]})
                        :headers json-headers}
           txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
@@ -102,10 +102,10 @@
     (let [ledger-name (create-rand-ledger "query-endpoint-selectOne-test")
           txn-req     {:body
                        (json/write-value-as-string
-                        {"ledger" ledger-name
-                         "txn"    [{"id"      "ex:query-test"
-                                    "type"    "schema:Test"
-                                    "ex:name" "query-test"}]})
+                         {"@id" ledger-name
+                          "@graph"    [{"id"      "ex:query-test"
+                                        "type"    "schema:Test"
+                                        "ex:name" "query-test"}]})
                        :headers json-headers}
           txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
@@ -127,52 +127,52 @@
           txn-req     {:headers json-headers
                        :body
                        (json/write-value-as-string
-                        {"ledger" ledger-name
-                         "txn"
-                         {"defaultContext"
-                          {"id"     "@id"
-                           "type"   "@type"
-                           "xsd"    "http://www.w3.org/2001/XMLSchema#"
-                           "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                           "rdfs"   "http://www.w3.org/2000/01/rdf-schema#"
-                           "sh"     "http://www.w3.org/ns/shacl#"
-                           "schema" "http://schema.org/"
-                           "skos"   "http://www.w3.org/2008/05/skos#"
-                           "wiki"   "https://www.wikidata.org/wiki/"
-                           "f"      "https://ns.flur.ee/ledger#"
-                           "ex"     "http://example.org/"}
-                          "txn" {"@graph"
-                                 [{"@id"         "ex:freddy"
-                                   "@type"       "ex:Yeti"
-                                   "schema:age"  4
-                                   "schema:name" "Freddy"
-                                   "ex:verified" true}
-                                  {"@id"         "ex:letty"
-                                   "@type"       "ex:Yeti"
-                                   "schema:age"  2
-                                   "ex:nickname" "Letty"
-                                   "schema:name" "Leticia"
-                                   "schema:follows"
-                                   [{"@type"  "@id"
-                                     "@value" "ex:freddy"}]}
-                                  {"@id"         "ex:betty"
-                                   "@type"       "ex:Yeti"
-                                   "schema:age"  82
-                                   "schema:name" "Betty"
-                                   "schema:follows"
-                                   [{"@type"  "@id"
-                                     "@value" "ex:freddy"}]}
-                                  {"@id"         "ex:andrew"
-                                   "@type"       "schema:Person"
-                                   "schema:age"  35
-                                   "schema:name" "Andrew Johnson"
-                                   "schema:follows"
-                                   [{"@type"  "@id"
-                                     "@value" "ex:freddy"}
-                                    {"@type"  "@id"
-                                     "@value" "ex:letty"}
-                                    {"@type"  "@id"
-                                     "@value" "ex:betty"}]}]}}})}
+                         {"@id" ledger-name
+                          "@graph"
+                          {"defaultContext"
+                           {"id"     "@id"
+                            "type"   "@type"
+                            "xsd"    "http://www.w3.org/2001/XMLSchema#"
+                            "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                            "rdfs"   "http://www.w3.org/2000/01/rdf-schema#"
+                            "sh"     "http://www.w3.org/ns/shacl#"
+                            "schema" "http://schema.org/"
+                            "skos"   "http://www.w3.org/2008/05/skos#"
+                            "wiki"   "https://www.wikidata.org/wiki/"
+                            "f"      "https://ns.flur.ee/ledger#"
+                            "ex"     "http://example.org/"}
+                           "txn" {"@graph"
+                                  [{"@id"         "ex:freddy"
+                                    "@type"       "ex:Yeti"
+                                    "schema:age"  4
+                                    "schema:name" "Freddy"
+                                    "ex:verified" true}
+                                   {"@id"         "ex:letty"
+                                    "@type"       "ex:Yeti"
+                                    "schema:age"  2
+                                    "ex:nickname" "Letty"
+                                    "schema:name" "Leticia"
+                                    "schema:follows"
+                                    [{"@type"  "@id"
+                                      "@value" "ex:freddy"}]}
+                                   {"@id"         "ex:betty"
+                                    "@type"       "ex:Yeti"
+                                    "schema:age"  82
+                                    "schema:name" "Betty"
+                                    "schema:follows"
+                                    [{"@type"  "@id"
+                                      "@value" "ex:freddy"}]}
+                                   {"@id"         "ex:andrew"
+                                    "@type"       "schema:Person"
+                                    "schema:age"  35
+                                    "schema:name" "Andrew Johnson"
+                                    "schema:follows"
+                                    [{"@type"  "@id"
+                                      "@value" "ex:freddy"}
+                                     {"@type"  "@id"
+                                      "@value" "ex:letty"}
+                                     {"@type"  "@id"
+                                      "@value" "ex:betty"}]}]}}})}
 
           txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
@@ -198,13 +198,13 @@
   (testing "can query a basic entity w/ EDN"
     (let [ledger-name (create-rand-ledger "query-endpoint-basic-entity-test")
           txn-req     {:body
-                       (pr-str {:ledger ledger-name
-                                :txn    [{:id      :ex/query-test
-                                          :type    :schema/Test
-                                          :ex/name "query-test"}]})
+                       (pr-str {:id ledger-name
+                                :graph    [{:id      :ex/query-test
+                                            :type    :schema/Test
+                                            :ex/name "query-test"}]})
                        :headers edn-headers}
           txn-res     (api-post :transact txn-req)
-          _           (assert (= 200 (:status txn-res)))
+          _           (assert (= 200 (:status txn-res)) (str "response was: " txn-res))
           query-req   {:body
                        (pr-str {:from ledger-name
                                 :select '{?t [:*]}

--- a/test/fluree/http_api/integration/basic_transaction_test.clj
+++ b/test/fluree/http_api/integration/basic_transaction_test.clj
@@ -21,24 +21,7 @@
       (is (= {"address" address
               "alias"   ledger-name
               "t"       1}
-             (-> res :body json/read-value))))))
-
-(deftest ^:integration ^:edn create-endpoint-edn-test
-  (testing "can create a new ledger w/ EDN"
-    (let [ledger-name (str "create-endpoint-" (random-uuid))
-          address     (str "fluree:memory://" ledger-name "/main/head")
-          req         (pr-str {:ledger         ledger-name
-                               :defaultContext ["" {:foo "http://foobar.com/"}]
-                               :txn            [{:id      :ex/create-test
-                                                 :type    :foo/test
-                                                 :ex/name "create-endpoint-test"}]})
-          res         (api-post :create {:body req :headers edn-headers})]
-      (is (= 201 (:status res)))
-      (is (= {:address address
-              :alias   ledger-name
-              :t       1}
-             (-> res :body edn/read-string)))))
-
+             (-> res :body json/read-value)))))
   (testing "responds with 409 error if ledger already exists"
     (let [ledger-name (str "create-endpoint-" (random-uuid))
           req         (pr-str {:ledger         ledger-name
@@ -51,30 +34,89 @@
           res-fail    (api-post :create {:body req :headers edn-headers})]
       (is (= 409 (:status res-fail))))))
 
+(deftest ^:integration ^:edn create-endpoint-edn-test
+    (testing "can create a new ledger w/ EDN"
+      (let [ledger-name (str "create-endpoint-" (random-uuid))
+            address     (str "fluree:memory://" ledger-name "/main/head")
+            req         (pr-str {:ledger         ledger-name
+                                 :defaultContext ["" {:foo "http://foobar.com/"}]
+                                 :txn            [{:id      :ex/create-test
+                                                   :type    :foo/test
+                                                   :ex/name "create-endpoint-test"}]})
+            res         (api-post :create {:body req :headers edn-headers})]
+        (is (= 201 (:status res)))
+        (is (= {:address address
+                :alias   ledger-name
+                :t       1}
+               (-> res :body edn/read-string)))))
+    (testing "responds with 409 error if ledger already exists"
+      (let [ledger-name (str "create-endpoint-" (random-uuid))
+            req         (pr-str {:ledger         ledger-name
+                                 :defaultContext ["" {:foo "http://foobar.com/"}]
+                                 :txn            [{:id      :ex/create-test
+                                                   :type    :foo/test
+                                                   :ex/name "create-endpoint-test"}]})
+            res-success (api-post :create {:body req :headers edn-headers})
+            _           (assert (= 201 (:status res-success)))
+            res-fail    (api-post :create {:body req :headers edn-headers})]
+        (is (= 409 (:status res-fail))))))
+
 (deftest ^:integration ^:json transaction-json-test
   (testing "can transact in JSON"
     (let [ledger-name (create-rand-ledger "transact-endpoint-json-test")
           address     (str "fluree:memory://" ledger-name "/main/head")
           req         (json/write-value-as-string
-                       {"ledger" ledger-name
-                        "txn"    {"id"      "ex:transaction-test"
-                                  "type"    "schema:Test"
-                                  "ex:name" "transact-endpoint-json-test"}})
+                        {"@id" ledger-name
+                         "@graph"    {"id"      "ex:transaction-test"
+                                      "type"    "schema:Test"
+                                      "ex:name" "transact-endpoint-json-test"}})
+          res         (api-post :transact {:body req :headers json-headers})]
+      (is (= 200 (:status res)))
+      (is (= {"address" address, "alias" ledger-name, "t" 2}
+             (-> res :body json/read-value)))))
+  (testing "can transact in JSON with top-level @context"
+    (let [ledger-name (create-rand-ledger "transact-endpoint-json-test")
+          address     (str "fluree:memory://" ledger-name "/main/head")
+          req         (json/write-value-as-string
+                        {"@id" ledger-name
+                         "@context" {"foo" "http://foo.com"}
+                         "@graph"    {"id"      "ex:transaction-test"
+                                      "type"    "schema:Test"
+                                      "foo:bar" "Baz"
+                                      "ex:name" "transact-endpoint-json-test"}})
+          res         (api-post :transact {:body req :headers json-headers})]
+      (is (= 200 (:status res)))
+      (is (= {"address" address, "alias" ledger-name, "t" 2}
+             (-> res :body json/read-value))))
+
+    (let [ledger-name (create-rand-ledger "transact-endpoint-json-test")
+          address     (str "fluree:memory://" ledger-name "/main/head")
+          req         (json/write-value-as-string
+                        {"@id" ledger-name
+                         "@context" {"foo" "http://foo.com"}
+                         "@graph"    [{"id"      "ex:transaction-test"
+                                       "type"    "schema:Test"
+                                       "foo:bar" "Baz"
+                                       "ex:name" "transact-endpoint-json-test"}
+                                      {"id"      "ex:transaction-test2"
+                                       "type"    "schema:Test"
+                                       "foo:bar" "Quux"
+                                       "ex:name" "transact-endpoint-json-test2"}]})
           res         (api-post :transact {:body req :headers json-headers})]
       (is (= 200 (:status res)))
       (is (= {"address" address, "alias" ledger-name, "t" 2}
              (-> res :body json/read-value))))))
 
 (deftest ^:integration ^:edn transaction-edn-test
-  (testing "can transact in EDN"
-    (let [ledger-name (create-rand-ledger "transact-endpoint-edn-test")
-          address     (str "fluree:memory://" ledger-name "/main/head")
-          req         (pr-str
-                       {:ledger ledger-name
-                        :txn    [{:id      :ex/transaction-test
-                                  :type    :schema/Test
-                                  :ex/name "transact-endpoint-edn-test"}]})
-          res         (api-post :transact {:body req :headers edn-headers})]
-      (is (= 200 (:status res)))
-      (is (= {:address address, :alias ledger-name, :t 2}
-             (-> res :body edn/read-string))))))
+    (testing "can transact in EDN"
+      (let [ledger-name (create-rand-ledger "transact-endpoint-edn-test")
+            address     (str "fluree:memory://" ledger-name "/main/head")
+            req         (pr-str
+                          {:id ledger-name
+                           :graph    [{:id      :ex/transaction-test
+                                       :type    :schema/Test
+                                       :ex/name "transact-endpoint-edn-test"}]})
+            res         (api-post :transact {:body req :headers edn-headers})]
+        (is (= 200 (:status res)))
+        (is (= {:address address, :alias ledger-name, :t 2}
+               (-> res :body edn/read-string))))))

--- a/test/fluree/http_api/integration/basic_transaction_test.clj
+++ b/test/fluree/http_api/integration/basic_transaction_test.clj
@@ -112,7 +112,9 @@
       (let [ledger-name (create-rand-ledger "transact-endpoint-edn-test")
             address     (str "fluree:memory://" ledger-name "/main/head")
             req         (pr-str
-                          {:id ledger-name
+                          {:context {:id "@id"
+                                     :graph "@graph"}
+                           :id ledger-name
                            :graph    [{:id      :ex/transaction-test
                                        :type    :schema/Test
                                        :ex/name "transact-endpoint-edn-test"}]})

--- a/test/fluree/http_api/integration/credential_test.clj
+++ b/test/fluree/http_api/integration/credential_test.clj
@@ -45,11 +45,11 @@
                (-> create-res :body json/read-value)))))
     (testing "transact"
       (let [txn-req (async/<!! (cred/generate
-                                 {"ledger" ledger-name
-                                  "txn"    [{"id"      "ex:cred-test"
-                                             "type"    "schema:Test"
-                                             "ex:name" "cred test"
-                                             "ex:foo"  1}]}
+                                 {"@id" ledger-name
+                                  "@graph"    [{"id"      "ex:cred-test"
+                                                "type"    "schema:Test"
+                                                "ex:name" "cred test"
+                                                "ex:foo"  1}]}
                                  (:private test-utils/auth)))
             txn-res (test-utils/api-post :transact {:body (json/write-value-as-string txn-req)
                                                     :headers  test-utils/json-headers})]

--- a/test/fluree/http_api/integration/credential_test.clj
+++ b/test/fluree/http_api/integration/credential_test.clj
@@ -69,7 +69,7 @@
         (is (= [{"ex:name"  "cred test",
                  "ex:foo"   1,
                  "id"       "ex:cred-test"
-                 "rdf:type" ["schema:Test"]}]
+                 "type" "schema:Test"}]
                (-> query-res :body json/read-value)))))
 
     (testing "history"
@@ -86,7 +86,7 @@
                  [{"ex:name" "cred test",
                    "ex:foo" 1,
                    "id" "ex:cred-test",
-                   "rdf:type" ["schema:Test"]}],
+                   "type" "schema:Test"}],
                  "f:t" 2}]
                (-> history-res :body json/read-value)))))
 

--- a/test/fluree/http_api/integration/default_context_test.clj
+++ b/test/fluree/http_api/integration/default_context_test.clj
@@ -22,7 +22,6 @@
               "type"   "@type"}
              (-> default-context-res :body json/read-value)))))
 
-  ;;TODO: "defaultContext" key
   (testing "can retrieve default context at a specific t"
     (let [ledger-name          (create-rand-ledger "get-default-context-test")
           default-context-req  {:body    (json/write-value-as-string
@@ -99,7 +98,6 @@
               "type"    "@type"}
              (-> default-context3-res :body json/read-value))))))
 
-;;TODO: "defaultContext" key
 (deftest ^:integration update-default-context-test
   (testing "can update default context for a ledger"
     (let [ledger-name          (create-rand-ledger "get-default-context-test")

--- a/test/fluree/http_api/integration/default_context_test.clj
+++ b/test/fluree/http_api/integration/default_context_test.clj
@@ -40,19 +40,22 @@
                                    (dissoc "foo"))
           txn0-req             {:body
                                 (json/write-value-as-string
-                                  {"@id"             ledger-name
-                                   "@graph"          [{"id"      "ex:nobody"
-                                                       "ex:name" "Nobody"}]
-                                   "defaultContext" default-context1})
+                                  {"@context"       {"f" "https://ns.flur.ee/ledger#" }
+                                   "@id"            ledger-name
+                                   "@graph"         [{"id"      "ex:nobody"
+                                                      "ex:name" "Nobody"}]
+                                   "f:defaultContext" default-context1})
                                 :headers json-headers}
           txn0-res             (api-post :transact txn0-req)
           _                    (assert (= 200 (:status txn0-res)) (str "result was " txn0-res))
           txn1-req             {:body
                                 (json/write-value-as-string
-                                  {"@id"             ledger-name
-                                   "@graph"          [{"id"      "ex:somebody"
-                                                       "ex:name" "Somebody"}]
-                                   "defaultContext" default-context2})
+                                  {"@context" {"f" "https://ns.flur.ee/ledger#" }
+
+                                   "@id"              ledger-name
+                                   "@graph"           [{"id"      "ex:somebody"
+                                                        "ex:name" "Somebody"}]
+                                   "f:defaultContext" default-context2})
                                 :headers json-headers}
           txn1-res             (api-post :transact txn1-req)
           _                    (assert (= 200 (:status txn1-res)))
@@ -106,9 +109,10 @@
           default-context-res  (api-get :defaultContext default-context-req)
           default-context-0    (-> default-context-res :body json/read-value)
           update-req           {:body    (json/write-value-as-string
-                                           {"@id" ledger-name
+                                           {"@context"       {"f" "https://ns.flur.ee/ledger#" }
+                                            "@id" ledger-name
                                             "@graph"    [{:ex/name "Foo"}]
-                                            "defaultContext"
+                                            "f:defaultContext"
                                             (-> default-context-0
                                                 (assoc "foo-new"
                                                        (get default-context-0 "foo"))

--- a/test/fluree/http_api/integration/default_context_test.clj
+++ b/test/fluree/http_api/integration/default_context_test.clj
@@ -22,6 +22,7 @@
               "type"   "@type"}
              (-> default-context-res :body json/read-value)))))
 
+  ;;TODO: "defaultContext" key
   (testing "can retrieve default context at a specific t"
     (let [ledger-name          (create-rand-ledger "get-default-context-test")
           default-context-req  {:body    (json/write-value-as-string
@@ -39,19 +40,19 @@
                                    (dissoc "foo"))
           txn0-req             {:body
                                 (json/write-value-as-string
-                                 {:ledger         ledger-name
-                                  :txn            [{"id"      "ex:nobody"
-                                                    "ex:name" "Nobody"}]
-                                  :defaultContext default-context1})
+                                  {"@id"             ledger-name
+                                   "@graph"          [{"id"      "ex:nobody"
+                                                       "ex:name" "Nobody"}]
+                                   "defaultContext" default-context1})
                                 :headers json-headers}
           txn0-res             (api-post :transact txn0-req)
-          _                    (assert (= 200 (:status txn0-res)))
+          _                    (assert (= 200 (:status txn0-res)) (str "result was " txn0-res))
           txn1-req             {:body
                                 (json/write-value-as-string
-                                 {:ledger         ledger-name
-                                  :txn            [{"id"      "ex:somebody"
-                                                    "ex:name" "Somebody"}]
-                                  :defaultContext default-context2})
+                                  {"@id"             ledger-name
+                                   "@graph"          [{"id"      "ex:somebody"
+                                                       "ex:name" "Somebody"}]
+                                   "defaultContext" default-context2})
                                 :headers json-headers}
           txn1-res             (api-post :transact txn1-req)
           _                    (assert (= 200 (:status txn1-res)))
@@ -95,6 +96,7 @@
               "type"    "@type"}
              (-> default-context3-res :body json/read-value))))))
 
+;;TODO: "defaultContext" key
 (deftest ^:integration update-default-context-test
   (testing "can update default context for a ledger"
     (let [ledger-name          (create-rand-ledger "get-default-context-test")
@@ -104,16 +106,16 @@
           default-context-res  (api-get :defaultContext default-context-req)
           default-context-0    (-> default-context-res :body json/read-value)
           update-req           {:body    (json/write-value-as-string
-                                          {:ledger ledger-name
-                                           :txn    [{:ex/name "Foo"}]
-                                           :defaultContext
-                                           (-> default-context-0
-                                               (assoc "foo-new"
-                                                      (get default-context-0 "foo"))
-                                               (dissoc "foo"))})
+                                           {"@id" ledger-name
+                                            "@graph"    [{:ex/name "Foo"}]
+                                            "defaultContext"
+                                            (-> default-context-0
+                                                (assoc "foo-new"
+                                                       (get default-context-0 "foo"))
+                                                (dissoc "foo"))})
                                 :headers json-headers}
           update-res           (api-post :transact update-req)
-          _                    (assert (= 200 (:status update-res)))
+          _                    (assert (= 200 (:status update-res)) (str "result was " update-res))
           default-context-res' (api-get :defaultContext default-context-req)
           default-context-1    (-> default-context-res' :body json/read-value)]
       (is (= 200 (:status update-res)))

--- a/test/fluree/http_api/integration/history_query_test.clj
+++ b/test/fluree/http_api/integration/history_query_test.clj
@@ -32,9 +32,9 @@
           _             (assert (= 201 (:status txn-res)))
           txn2-req      {:body
                          (json/write-value-as-string
-                          {"ledger" ledger-name
-                           "txn"    [{"id"           "ex:query-test"
-                                      "ex:test-type" "integration"}]})
+                           {"@id" ledger-name
+                            "@graph"    [{"id"           "ex:query-test"
+                                          "ex:test-type" "integration"}]})
                          :headers json-headers}
           txn2-res      (api-post :transact txn2-req)
           _             (assert (= 200 (:status txn2-res)))
@@ -89,9 +89,9 @@
           _             (assert (= 201 (:status txn-res)))
           txn2-req      {:body
                          (pr-str
-                          {:ledger ledger-name
-                           :txn    [{:id           :ex/query-test
-                                     :ex/test-type "integration"}]})
+                           {:id ledger-name
+                            :graph    [{:id           :ex/query-test
+                                        :ex/test-type "integration"}]})
                          :headers edn-headers}
           txn2-res      (api-post :transact txn2-req)
           _             (assert (= 200 (:status txn2-res)))

--- a/test/fluree/http_api/integration/history_query_test.clj
+++ b/test/fluree/http_api/integration/history_query_test.clj
@@ -89,7 +89,9 @@
           _             (assert (= 201 (:status txn-res)))
           txn2-req      {:body
                          (pr-str
-                           {:id ledger-name
+                           {:context {:id "@id"
+                                      :graph "@graph"}
+                            :id ledger-name
                             :graph    [{:id           :ex/query-test
                                         :ex/test-type "integration"}]})
                          :headers edn-headers}

--- a/test/fluree/http_api/integration/policy_test.clj
+++ b/test/fluree/http_api/integration/policy_test.clj
@@ -5,7 +5,7 @@
             [jsonista.core :as json]))
 
 (use-fixtures :once run-test-server)
-;;TODO: opts key
+
 (deftest ^:integration ^:json policy-opts-json-test
   (testing "policy-enforcing opts are correctly handled"
     (let [ledger-name  (create-rand-ledger "policy-opts-test")
@@ -112,7 +112,6 @@
                    (-> query-res :body json/read-value first (get "f:assert")))
                 "policy opts should have prevented seeing bob's secret")))))))
 
-;;TODO: opts key
 (deftest ^:integration ^:edn policy-opts-edn-test
   (testing "policy-enforcing opts are correctly handled"
     (let [ledger-name  (create-rand-ledger "policy-opts-test")

--- a/test/fluree/http_api/integration/policy_test.clj
+++ b/test/fluree/http_api/integration/policy_test.clj
@@ -52,9 +52,9 @@
           query-res    (api-post :query query-req)]
       (is (= 200 (:status query-res))
           (str "policy-enforced query response was: " (pr-str query-res)))
-      (is (= [{"id" "ex:bob", "rdf:type" ["ex:User"]}
+      (is (= [{"id" "ex:bob", "type" "ex:User"}
               {"id"        "ex:alice",
-               "rdf:type"  ["ex:User"],
+               "type"  "ex:User",
                "ex:secret" "alice's secret"}]
              (-> query-res :body json/read-value))
           "query policy opts should prevent seeing bob's secret")
@@ -75,10 +75,10 @@
             query-res (api-post :query query-req)
             _         (assert (= 200 (:status query-res)))]
         (is (= [{"id"        "ex:bob",
-                 "rdf:type"  ["ex:User"],
+                 "type"  "ex:User",
                  "ex:secret" "bob's secret"}
                 {"id"        "ex:alice",
-                 "rdf:type"  ["ex:User"],
+                 "type"  "ex:User",
                  "ex:secret" "alice's NEW secret"}]
                (-> query-res :body json/read-value))
             "alice's secret should be modified")
@@ -104,7 +104,7 @@
                 query-res (api-post :history query-req)]
             (is (= 200 (:status query-res))
                 (str "History query response was: " (pr-str query-res)))
-            (is (= [{"id" "ex:bob", "rdf:type" ["ex:User"]}]
+            (is (= [{"id" "ex:bob", "type" "ex:User"}]
                    (-> query-res :body json/read-value first (get "f:assert")))
                 "policy opts should have prevented seeing bob's secret")))))))
 
@@ -151,10 +151,10 @@
           query-res    (api-post :query query-req)]
       (is (= 200 (:status query-res))
           (str "policy-enforced query response was: " (pr-str query-res)))
-      (is (= [{:id       :ex/bob
-               :rdf/type [:ex/User]}
+      (is (= [{:id   :ex/bob
+               :type :ex/User}
               {:id        :ex/alice
-               :rdf/type  [:ex/User]
+               :type      :ex/User
                :ex/secret "alice's secret"}]
              (-> query-res :body edn/read-string))
           "query policy opts should prevent seeing bob's secret")
@@ -175,10 +175,10 @@
             query-res (api-post :query query-req)
             _         (assert (= 200 (:status query-res)))]
         (is (= [{:id        :ex/bob
-                 :rdf/type  [:ex/User]
+                 :type      :ex/User
                  :ex/secret "bob's secret"}
                 {:id        :ex/alice
-                 :rdf/type  [:ex/User]
+                 :type      :ex/User
                  :ex/secret "alice's NEW secret"}]
                (-> query-res :body edn/read-string))
             "alice's secret should be modified")
@@ -204,6 +204,6 @@
                 query-res (api-post :history query-req)]
             (is (= 200 (:status query-res))
                 (str "History query response was: " (pr-str query-res)))
-            (is (= [{:id :ex/bob :rdf/type [:ex/User]}]
+            (is (= [{:id :ex/bob :type :ex/User}]
                    (-> query-res :body edn/read-string first :f/assert))
                 "policy opts should have prevented seeing bob's secret")))))))


### PR DESCRIPTION
Part of https://github.com/fluree/core/issues/20
Related db PR: https://github.com/fluree/db/pull/561

This PR updates the `/transact` endpoint to use the new version of db which expects a json-ld document in the transaction request.

Parsing/validation of that document is now handled by db, which will do the expansion necessary to find the required keys and throw an error if they do not exist. As a result, the spec has been simplified, and the `/transact` endpoint is now a very thin wrapper that mostly just passes through to db.
