### PR TITLE
Feature: SPARQL query support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.11.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "df7b44dd02f6b7f8a395e56fb4e7c27e9fb9ee3a"}}
+                                         :git/sha "7834d151a750f7d148f36ce50739448ba11933d0"}}
 
 
  :aliases

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.11.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "7cbcd44a90a436b458897e1210e05d533031742f"}}
+                                         :git/sha "df7b44dd02f6b7f8a395e56fb4e7c27e9fb9ee3a"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.11.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "e3f36f620ff26d1f1120a1d0fd9b765664005f40"}}
+                                         :git/sha "7cbcd44a90a436b458897e1210e05d533031742f"}}
 
  :aliases
  {:dev

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -103,14 +103,14 @@
     (fn [{:keys [fluree/conn content-type credential/did]
           {:keys [body]} :parameters}]
       (let [query  (or (::http/query body) body)
-            format (or (::http/format body) :fql)]
-        (log/debug "query handler received query:" query)
-        (let [opts   (when (= :fql format)
-                       (cond-> (query-body->opts query content-type)
-                         did (assoc :did did)))
-              query* (if opts (assoc query :opts opts) query)]
-          {:status 200
-           :body   (deref! (fluree/from-query conn query* {:format format}))})))))
+            format (or (::http/format body) :fql)
+            _      (log/debug "query handler received query:" query)
+            opts   (when (= :fql format)
+                     (cond-> (query-body->opts query content-type)
+                       did (assoc :did did)))
+            query* (if opts (assoc query :opts opts) query)]
+        {:status 200
+         :body   (deref! (fluree/from-query conn query* {:format format}))}))))
 
 (def history
   (error-catching-handler

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -3,7 +3,8 @@
    [clojure.string :as str]
    [fluree.db.json-ld.api :as fluree]
    [fluree.db.util.core :as util]
-   [fluree.db.util.log :as log])
+   [fluree.db.util.log :as log]
+   [fluree.http-api.components.http :as-alias http])
   (:import (clojure.lang ExceptionInfo)))
 
 (defn deref!
@@ -99,17 +100,17 @@
 
 (def query
   (error-catching-handler
-    (fn [{:keys [fluree/conn content-type credential/did] {{ledger :from :as query} :body} :parameters}]
-      (log/debug "query handler received query:" query)
-      (let [db     (->> ledger (fluree/load conn) deref! fluree/db)
-            opts (cond-> (query-body->opts query content-type)
-                   did (assoc :did did))
-            query* (-> query
-                       (assoc :opts opts)
-                       (dissoc :from))]
-        (log/debug "query - Querying ledger" ledger "-" query*)
-        {:status 200
-         :body   (deref! (fluree/query db query*))}))))
+    (fn [{:keys [fluree/conn content-type credential/did]
+          {:keys [body]} :parameters}]
+      (let [query  (or (::http/query body) body)
+            format (or (::http/format body) :fql)]
+        (log/debug "query handler received query:" query)
+        (let [opts   (when (= :fql format)
+                       (cond-> (query-body->opts query content-type)
+                         did (assoc :did did)))
+              query* (if opts (assoc query :opts opts) query)]
+          {:status 200
+           :body   (deref! (fluree/from-query conn query* {:format format}))})))))
 
 (def history
   (error-catching-handler

--- a/test/fluree/http_api/integration/basic_query_test.clj
+++ b/test/fluree/http_api/integration/basic_query_test.clj
@@ -11,10 +11,10 @@
     (let [ledger-name (create-rand-ledger "query-endpoint-basic-entity-test")
           txn-req     {:body
                        (json/write-value-as-string
-                         {"@id" ledger-name
-                          "@graph"    [{"id"      "ex:query-test"
-                                        "type"    "schema:Test"
-                                        "ex:name" "query-test"}]})
+                         {"@id"    ledger-name
+                          "@graph" [{"id"      "ex:query-test"
+                                     "type"    "schema:Test"
+                                     "ex:name" "query-test"}]})
                        :headers json-headers}
           txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
@@ -213,7 +213,6 @@
                                 :where  '[[?t :type :schema/Test]]})
                        :headers edn-headers}
           query-res   (api-post :query query-req)]
-      (println "Q" query-req)
       (is (= 200 (:status query-res))
           (str "Query response was:" (pr-str query-res)))
       (is (= [{:id      :ex/query-test

--- a/test/fluree/http_api/integration/sparql_test.clj
+++ b/test/fluree/http_api/integration/sparql_test.clj
@@ -1,0 +1,28 @@
+(ns fluree.http-api.integration.sparql-test
+  (:require [clojure.test :refer :all]
+            [fluree.http-api.integration.test-system :refer :all]
+            [jsonista.core :as json]))
+
+(use-fixtures :once run-test-server)
+
+(deftest ^:integration ^:sparql query-sparql-test
+  (testing "basic SPARQL query works"
+    (let [ledger-name (create-rand-ledger "query-sparql-test")
+          txn-req     {:body
+                       (json/write-value-as-string
+                        {"@id"    ledger-name
+                         "@graph" [{"id"      "ex:query-sparql-test"
+                                    "type"    "schema:Test"
+                                    "ex:name" "query-sparql-test"}]})
+                       :headers json-headers}
+          txn-res     (api-post :transact txn-req)
+          _           (assert (= 200 (:status txn-res)))
+          query-req   {:body    (str "SELECT ?name
+                                      FROM   <" ledger-name ">
+                                      WHERE  {?test <type> schema:Test;
+                                                    ex:name ?name.}")
+                       :headers sparql-headers}
+          query-res   (api-post :query query-req)]
+      (is (= 200 (:status query-res)))
+      (is (= [["query-sparql-test"]]
+             (-> query-res :body json/read-value))))))

--- a/test/fluree/http_api/integration/test_system.clj
+++ b/test/fluree/http_api/integration/test_system.clj
@@ -13,6 +13,10 @@
   {"Content-Type" "application/edn"
    "Accept"       "application/edn"})
 
+(def sparql-headers
+  {"Content-Type" "application/sparql-query"
+   "Accept"       "application/json"})
+
 (defn find-open-port
   ([] (find-open-port nil))
   ([_] ; so it can be used in swap!


### PR DESCRIPTION
This and https://github.com/fluree/db/pull/566 adds support for SPARQL queries. See the new test for an example of how they work. The most important parts are that you set the `Content-Type` header to `application/sparql-query` and put the ledger you want to query in the `FROM` clause, wrapped in angle brackets (to tell the SPARQL parser that it's an IRI).