### PR TITLE
Feature: unify /create keys with /transact

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,6 @@
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
                                          :git/sha "7834d151a750f7d148f36ce50739448ba11933d0"}}
 
-
  :aliases
  {:dev
   {:extra-paths ["dev/src" "test"]

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.12.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "b15ae2ddca04300efe4e423a6f995e8a4811cb64"}}
+                                         :git/sha "7aefac5fc79029b13b6924486b621b13c6d428df"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -1,14 +1,14 @@
 {:paths ["src" "resources"]
  :deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
-         org.clojure/core.async         {:mvn/version "1.6.673"}
+         org.clojure/core.async         {:mvn/version "1.6.681"}
          club.donutpower/system         {:mvn/version "0.0.165"}
          aero/aero                      {:mvn/version "1.1.6"}
-         info.sunng/ring-jetty9-adapter {:mvn/version "0.22.0"}
-         ch.qos.logback/logback-classic {:mvn/version "1.4.8"}
-         org.slf4j/slf4j-api            {:mvn/version "2.0.7"}
+         info.sunng/ring-jetty9-adapter {:mvn/version "0.22.1"}
+         ch.qos.logback/logback-classic {:mvn/version "1.4.11"}
+         org.slf4j/slf4j-api            {:mvn/version "2.0.9"}
          metosin/reitit                 {:mvn/version "0.6.0"}
          metosin/muuntaja               {:mvn/version "0.6.8"}
-         metosin/malli                  {:mvn/version "0.11.0"}
+         metosin/malli                  {:mvn/version "0.12.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
                                          :git/sha "7834d151a750f7d148f36ce50739448ba11933d0"}}
@@ -27,7 +27,7 @@
 
   :test
   {:extra-paths ["test"]
-   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.85.1342"}
+   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.86.1355"}
                  clj-http/clj-http   {:mvn/version "3.12.3"}}
    :exec-fn     kaocha.runner/exec-fn
    :exec-args   {}}

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.12.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "7834d151a750f7d148f36ce50739448ba11933d0"}}
+                                         :git/sha "b15ae2ddca04300efe4e423a6f995e8a4811cb64"}}
 
  :aliases
  {:dev

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -232,7 +232,6 @@
       (mt/transformer {:name :edn})
       (when default-values (mt/default-value-transformer))))))
 
->>>>>>> 9cdb7d5 (Use @id, @graph, @context in /create endpoint too)
 (defn websocket-handler
   [upgrade-request]
   ;; Mostly copy-pasta from

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -15,25 +15,25 @@
       (throw res)
       res)))
 
-(defn error-catching-handler
-  [handler]
-  (fn [req]
-    (try
-      (handler req)
-      (catch ExceptionInfo e
-        (if (-> e ex-data (contains? :response))
-          (throw e)
-          (let [msg   (ex-message e)
-                {:keys [status] :as data :or {status 500}} (ex-data e)
-                error (dissoc data :status)]
-            (throw (ex-info "Error in ledger handler"
-                            {:response
-                             {:status status
-                              :body   (assoc error :message msg)}})))))
-      (catch Throwable t
-        (throw (ex-info "Error in ledger handler"
-                        {:response {:status 500
-                                    :body   {:error (ex-message t)}}}))))))
+(defmacro defhandler
+  [name args & body]
+  `(defn ~name ~args
+     (try
+       ~@body
+       (catch ExceptionInfo e#
+         (if (-> e# ex-data (contains? :response))
+           (throw e#)
+           (let [msg#   (ex-message e#)
+                 {status# :status :as data# :or {status# 500}} (ex-data e#)
+                 error# (dissoc data# :status)]
+             (throw (ex-info "Error in ledger handler"
+                             {:response
+                              {:status status#
+                               :body   (assoc error# :message msg#)}})))))
+       (catch Throwable t#
+         (throw (ex-info "Error in ledger handler"
+                         {:response {:status 500
+                                     :body   {:error (ex-message t#)}}}))))))
 
 (defn header->content-type
   [ct-header]
@@ -56,91 +56,71 @@
   (let [content-type* (header->content-type content-type)]
     (assoc opts :context-type (content-type->context-type content-type*))))
 
-
 (defn ledger-summary
   [db]
   (assoc (-> db :ledger (select-keys [:alias :address]))
          :t (-> db :commit :data :t)))
 
-(def create
-  (error-catching-handler
-    (fn [{:keys [fluree/conn content-type credential/did]
-          {:keys [body]} :parameters}]
-      (log/debug "create body:" body)
-      (let [ledger         (get body "@id")
-            ledger-exists? (deref! (fluree/exists? conn ledger))]
-        (log/debug "Ledger" ledger "exists?" ledger-exists?)
-        (if ledger-exists?
-          (let [err-message (str "Ledger " ledger " already exists")]
-            (throw (ex-info err-message
-                            {:response {:status 409
-                                        :body   {:error err-message}}})))
-          (let [default-context (get body "@context")
-                opts            (:opts body)
-                opts*           (cond-> (opts->context-type opts content-type)
-                                  default-context (assoc :defaultContext default-context)
-                                  did (assoc :did did))
-                _       (log/info "Creating ledger" ledger opts*)
-                ledger* (deref! (fluree/create conn ledger opts*))
-                txn     (get body "@graph")
-                db      (-> ledger*
-                            fluree/db
-                            (fluree/stage txn opts*)
-                            deref!
-                            (->> (fluree/commit! ledger*))
-                            deref!)]
-            {:status 201
-             :body   (ledger-summary db)}))))))
+(defhandler create
+  [{:keys [fluree/conn content-type credential/did]
+    {:keys [body]} :parameters}]
+  (log/debug "create body:" body)
+  (let [opts (cond-> (opts->context-type {} content-type)
+               did (assoc :did did))
+        _    (log/trace "create opts:" opts)
+        db   (-> conn
+                 (fluree/create-with-txn body opts)
+                 deref!)]
+    (log/debug "create-with-txn result:" db)
+    {:status 201
+     :body   (ledger-summary db)}))
 
-(def transact
-  (error-catching-handler
-    (fn [{:keys [fluree/conn content-type credential/did]
-          {:keys [body]} :parameters}]
-      (let [opts    (cond-> (opts->context-type {} content-type)
-                      did (assoc :did did))
-            db      (-> (fluree/transact! conn body opts)
-                        deref!)]
-        {:status 200
-         :body   (ledger-summary db)}))))
+(defhandler transact
+  [{:keys [fluree/conn content-type credential/did]
+    {:keys [body]} :parameters}]
+  (let [opts (cond-> (opts->context-type {} content-type)
+               did (assoc :did did))
+        db   (-> conn
+                 (fluree/transact! body opts)
+                 deref!)]
+    {:status 200
+     :body   (ledger-summary db)}))
 
-(def query
-  (error-catching-handler
-    (fn [{:keys [fluree/conn content-type credential/did]
-          {:keys [body]} :parameters}]
-      (let [query  (or (::http/query body) body)
-            format (or (::http/format body) :fql)
-            _      (log/debug "query handler received query:" query)
-            opts   (when (= :fql format)
-                     (cond-> (query-body->opts query content-type)
-                       did (assoc :did did)))
-            query* (if opts (assoc query :opts opts) query)]
-        {:status 200
-         :body   (deref! (fluree/from-query conn query* {:format format}))}))))
+(defhandler query
+  [{:keys [fluree/conn content-type credential/did]
+    {:keys [body]} :parameters}]
+  (let [query  (or (::http/query body) body)
+        format (or (::http/format body) :fql)
+        _      (log/debug "query handler received query:" query)
+        opts   (when (= :fql format)
+                 (cond-> (query-body->opts query content-type)
+                   did (assoc :did did)))
+        query* (if opts (assoc query :opts opts) query)]
+    {:status 200
+     :body   (deref! (fluree/from-query conn query* {:format format}))}))
 
-(def history
-  (error-catching-handler
-    (fn [{:keys [fluree/conn content-type credential/did] {{ledger :from :as query} :body} :parameters}]
-      (log/debug "history handler got query:" query)
-      (let [ledger* (->> ledger (fluree/load conn) deref!)
-            opts (cond-> (query-body->opts query content-type)
-                   did (assoc :did did))
-            query*  (-> query
-                        (dissoc :from)
-                        (assoc :opts opts))]
-        (log/debug "history - Querying ledger" ledger "-" query*)
-        (let [results (deref! (fluree/history ledger* query*))]
-          (log/debug "history - query results:" results)
-          {:status 200
-           :body results})))))
+(defhandler history
+  [{:keys [fluree/conn content-type credential/did] {{ledger :from :as query} :body} :parameters}]
+  (log/debug "history handler got query:" query)
+  (let [ledger* (->> ledger (fluree/load conn) deref!)
+        opts (cond-> (query-body->opts query content-type)
+               did (assoc :did did))
+        query*  (-> query
+                    (dissoc :from)
+                    (assoc :opts opts))]
+    (log/debug "history - Querying ledger" ledger "-" query*)
+    (let [results (deref! (fluree/history ledger* query*))]
+      (log/debug "history - query results:" results)
+      {:status 200
+       :body results})))
 
-(def default-context
-  (error-catching-handler
-   (fn [{:keys [fluree/conn] {{:keys [ledger t] :as body} :body} :parameters}]
-     (log/debug "default-context handler got request:" body)
-     (let [ledger* (->> ledger (fluree/load conn) deref!)]
-       (let [results (if t
-                       (-> ledger* (fluree/default-context-at-t t) deref)
-                       (-> ledger* fluree/db fluree/default-context))]
-         (log/debug "default-context for ledger" (str ledger ":") results)
-         {:status 200
-          :body   results})))))
+(defhandler default-context
+  [{:keys [fluree/conn] {{:keys [ledger t] :as body} :body} :parameters}]
+  (log/debug "default-context handler got request:" body)
+  (let [ledger* (->> ledger (fluree/load conn) deref!)
+        results (if t
+                  (-> ledger* (fluree/default-context-at-t t) deref)
+                  (-> ledger* fluree/db fluree/default-context))]
+      (log/debug "default-context for ledger" (str ledger ":") results)
+      {:status 200
+       :body   results}))

--- a/test/fluree/http_api/integration/basic_transaction_test.clj
+++ b/test/fluree/http_api/integration/basic_transaction_test.clj
@@ -11,11 +11,11 @@
     (let [ledger-name (str "create-endpoint-" (random-uuid))
           address     (str "fluree:memory://" ledger-name "/main/head")
           req         (json/write-value-as-string
-                       {"ledger"         ledger-name
-                        "defaultContext" ["" {"foo" "http://foobar.com/"}]
-                        "txn"            [{"id"      "ex:create-test"
-                                           "type"    "foo:test"
-                                           "ex:name" "create-endpoint-test"}]})
+                       {"@id"      ledger-name
+                        "@context" ["" {"foo" "http://foobar.com/"}]
+                        "@graph"   [{"id"      "ex:create-test"
+                                     "type"    "foo:test"
+                                     "ex:name" "create-endpoint-test"}]})
           res         (api-post :create {:body req :headers json-headers})]
       (is (= 201 (:status res)))
       (is (= {"address" address
@@ -24,11 +24,11 @@
              (-> res :body json/read-value)))))
   (testing "responds with 409 error if ledger already exists"
     (let [ledger-name (str "create-endpoint-" (random-uuid))
-          req         (pr-str {:ledger         ledger-name
-                               :defaultContext ["" {:foo "http://foobar.com/"}]
-                               :txn            [{:id      :ex/create-test
-                                                 :type    :foo/test
-                                                 :ex/name "create-endpoint-test"}]})
+          req         (pr-str {:id      ledger-name
+                               :context ["" {:foo "http://foobar.com/"}]
+                               :graph   [{:id      :ex/create-test
+                                          :type    :foo/test
+                                          :ex/name "create-endpoint-test"}]})
           res-success (api-post :create {:body req :headers edn-headers})
           _           (assert (= 201 (:status res-success)))
           res-fail    (api-post :create {:body req :headers edn-headers})]
@@ -38,11 +38,11 @@
     (testing "can create a new ledger w/ EDN"
       (let [ledger-name (str "create-endpoint-" (random-uuid))
             address     (str "fluree:memory://" ledger-name "/main/head")
-            req         (pr-str {:ledger         ledger-name
-                                 :defaultContext ["" {:foo "http://foobar.com/"}]
-                                 :txn            [{:id      :ex/create-test
-                                                   :type    :foo/test
-                                                   :ex/name "create-endpoint-test"}]})
+            req         (pr-str {:id      ledger-name
+                                 :context ["" {:foo "http://foobar.com/"}]
+                                 :graph   [{:id      :ex/create-test
+                                            :type    :foo/test
+                                            :ex/name "create-endpoint-test"}]})
             res         (api-post :create {:body req :headers edn-headers})]
         (is (= 201 (:status res)))
         (is (= {:address address
@@ -51,11 +51,11 @@
                (-> res :body edn/read-string)))))
     (testing "responds with 409 error if ledger already exists"
       (let [ledger-name (str "create-endpoint-" (random-uuid))
-            req         (pr-str {:ledger         ledger-name
-                                 :defaultContext ["" {:foo "http://foobar.com/"}]
-                                 :txn            [{:id      :ex/create-test
-                                                   :type    :foo/test
-                                                   :ex/name "create-endpoint-test"}]})
+            req         (pr-str {:id      ledger-name
+                                 :context ["" {:foo "http://foobar.com/"}]
+                                 :graph   [{:id      :ex/create-test
+                                            :type    :foo/test
+                                            :ex/name "create-endpoint-test"}]})
             res-success (api-post :create {:body req :headers edn-headers})
             _           (assert (= 201 (:status res-success)))
             res-fail    (api-post :create {:body req :headers edn-headers})]
@@ -66,10 +66,10 @@
     (let [ledger-name (create-rand-ledger "transact-endpoint-json-test")
           address     (str "fluree:memory://" ledger-name "/main/head")
           req         (json/write-value-as-string
-                        {"@id" ledger-name
-                         "@graph"    {"id"      "ex:transaction-test"
-                                      "type"    "schema:Test"
-                                      "ex:name" "transact-endpoint-json-test"}})
+                        {"@id"    ledger-name
+                         "@graph" {"id"      "ex:transaction-test"
+                                   "type"    "schema:Test"
+                                   "ex:name" "transact-endpoint-json-test"}})
           res         (api-post :transact {:body req :headers json-headers})]
       (is (= 200 (:status res)))
       (is (= {"address" address, "alias" ledger-name, "t" 2}
@@ -78,12 +78,12 @@
     (let [ledger-name (create-rand-ledger "transact-endpoint-json-test")
           address     (str "fluree:memory://" ledger-name "/main/head")
           req         (json/write-value-as-string
-                        {"@id" ledger-name
+                        {"@id"      ledger-name
                          "@context" {"foo" "http://foo.com"}
-                         "@graph"    {"id"      "ex:transaction-test"
-                                      "type"    "schema:Test"
-                                      "foo:bar" "Baz"
-                                      "ex:name" "transact-endpoint-json-test"}})
+                         "@graph"   {"id"      "ex:transaction-test"
+                                     "type"    "schema:Test"
+                                     "foo:bar" "Baz"
+                                     "ex:name" "transact-endpoint-json-test"}})
           res         (api-post :transact {:body req :headers json-headers})]
       (is (= 200 (:status res)))
       (is (= {"address" address, "alias" ledger-name, "t" 2}
@@ -92,16 +92,16 @@
     (let [ledger-name (create-rand-ledger "transact-endpoint-json-test")
           address     (str "fluree:memory://" ledger-name "/main/head")
           req         (json/write-value-as-string
-                        {"@id" ledger-name
+                        {"@id"      ledger-name
                          "@context" {"foo" "http://foo.com"}
-                         "@graph"    [{"id"      "ex:transaction-test"
-                                       "type"    "schema:Test"
-                                       "foo:bar" "Baz"
-                                       "ex:name" "transact-endpoint-json-test"}
-                                      {"id"      "ex:transaction-test2"
-                                       "type"    "schema:Test"
-                                       "foo:bar" "Quux"
-                                       "ex:name" "transact-endpoint-json-test2"}]})
+                         "@graph"   [{"id"      "ex:transaction-test"
+                                      "type"    "schema:Test"
+                                      "foo:bar" "Baz"
+                                      "ex:name" "transact-endpoint-json-test"}
+                                     {"id"      "ex:transaction-test2"
+                                      "type"    "schema:Test"
+                                      "foo:bar" "Quux"
+                                      "ex:name" "transact-endpoint-json-test2"}]})
           res         (api-post :transact {:body req :headers json-headers})]
       (is (= 200 (:status res)))
       (is (= {"address" address, "alias" ledger-name, "t" 2}
@@ -114,10 +114,10 @@
             req         (pr-str
                           {:context {:id "@id"
                                      :graph "@graph"}
-                           :id ledger-name
-                           :graph    [{:id      :ex/transaction-test
-                                       :type    :schema/Test
-                                       :ex/name "transact-endpoint-edn-test"}]})
+                           :id      ledger-name
+                           :graph   [{:id      :ex/transaction-test
+                                      :type    :schema/Test
+                                      :ex/name "transact-endpoint-edn-test"}]})
             res         (api-post :transact {:body req :headers edn-headers})]
         (is (= 200 (:status res)))
         (is (= {:address address, :alias ledger-name, :t 2}

--- a/test/fluree/http_api/integration/credential_test.clj
+++ b/test/fluree/http_api/integration/credential_test.clj
@@ -25,17 +25,17 @@
   (let [ledger-name "credential-test"]
     (testing "create"
       ;; cannot transact without roles already defined
-      (let [create-req  {"ledger" ledger-name
-                         "defaultContext" default-context
-                         "txn"    [{"id"      (:id test-utils/auth)
-                                    "f:role"  {"id" "role:root"}
-                                    "type"    "schema:Person"
-                                    "ex:name" "Goose"}
-                                   {"id" "ex:rootPolicy"
-                                    "type" "f:Policy"
-                                    "f:targetNode" {"id" "f:allNodes"}
-                                    "f:allow" [{"f:targetRole" {"id" "role:root"}
-                                                "f:action" [{"id" "f:view"} {"id" "f:modify"}]}]}]}
+      (let [create-req  {"@id"      ledger-name
+                         "@context" default-context
+                         "@graph"   [{"id"      (:id test-utils/auth)
+                                      "f:role"  {"id" "role:root"}
+                                      "type"    "schema:Person"
+                                      "ex:name" "Goose"}
+                                     {"id" "ex:rootPolicy"
+                                      "type" "f:Policy"
+                                      "f:targetNode" {"id" "f:allNodes"}
+                                      "f:allow" [{"f:targetRole" {"id" "role:root"}
+                                                  "f:action" [{"id" "f:view"} {"id" "f:modify"}]}]}]}
             create-res  (test-utils/api-post :create {:body (json/write-value-as-string create-req)
                                                       :headers  test-utils/json-headers})]
         (is (= 201 (:status create-res)))

--- a/test/fluree/http_api/integration/default_context_test.clj
+++ b/test/fluree/http_api/integration/default_context_test.clj
@@ -19,7 +19,8 @@
               "id"     "@id"
               "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
               "schema" "http://schema.org/"
-              "type"   "@type"}
+              "type"   "@type"
+              "graph"  "@graph"}
              (-> default-context-res :body json/read-value)))))
 
   (testing "can retrieve default context at a specific t"
@@ -39,7 +40,7 @@
                                    (dissoc "foo"))
           txn0-req             {:body
                                 (json/write-value-as-string
-                                  {"@context"       {"f" "https://ns.flur.ee/ledger#" }
+                                  {"@context"       {"f" "https://ns.flur.ee/ledger#"}
                                    "@id"            ledger-name
                                    "@graph"         [{"id"      "ex:nobody"
                                                       "ex:name" "Nobody"}]
@@ -49,7 +50,7 @@
           _                    (assert (= 200 (:status txn0-res)) (str "result was " txn0-res))
           txn1-req             {:body
                                 (json/write-value-as-string
-                                  {"@context" {"f" "https://ns.flur.ee/ledger#" }
+                                  {"@context" {"f" "https://ns.flur.ee/ledger#"}
 
                                    "@id"              ledger-name
                                    "@graph"           [{"id"      "ex:somebody"
@@ -79,7 +80,8 @@
               "id"     "@id"
               "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
               "schema" "http://schema.org/"
-              "type"   "@type"}
+              "type"   "@type"
+              "graph"  "@graph"}
              (-> default-context1-res :body json/read-value)))
       (is (= {"ex-new" "http://example.com/"
               "f"      "https://ns.flur.ee/ledger#"
@@ -87,7 +89,8 @@
               "id"     "@id"
               "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
               "schema" "http://schema.org/"
-              "type"   "@type"}
+              "type"   "@type"
+              "graph"  "@graph"}
              (-> default-context2-res :body json/read-value)))
       (is (= {"ex-new"  "http://example.com/"
               "f"       "https://ns.flur.ee/ledger#"
@@ -95,7 +98,8 @@
               "id"      "@id"
               "rdf"     "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
               "schema"  "http://schema.org/"
-              "type"    "@type"}
+              "type"    "@type"
+              "graph"   "@graph"}
              (-> default-context3-res :body json/read-value))))))
 
 (deftest ^:integration update-default-context-test
@@ -107,9 +111,9 @@
           default-context-res  (api-get :defaultContext default-context-req)
           default-context-0    (-> default-context-res :body json/read-value)
           update-req           {:body    (json/write-value-as-string
-                                           {"@context"       {"f" "https://ns.flur.ee/ledger#" }
-                                            "@id" ledger-name
-                                            "@graph"    [{:ex/name "Foo"}]
+                                           {"@context" {"f" "https://ns.flur.ee/ledger#"}
+                                            "@id"      ledger-name
+                                            "@graph"   [{:ex/name "Foo"}]
                                             "f:defaultContext"
                                             (-> default-context-0
                                                 (assoc "foo-new"
@@ -117,7 +121,8 @@
                                                 (dissoc "foo"))})
                                 :headers json-headers}
           update-res           (api-post :transact update-req)
-          _                    (assert (= 200 (:status update-res)) (str "result was " update-res))
+          _                    (assert (= 200 (:status update-res))
+                                       (str "result was " update-res))
           default-context-res' (api-get :defaultContext default-context-req)
           default-context-1    (-> default-context-res' :body json/read-value)]
       (is (= 200 (:status update-res)))
@@ -127,5 +132,6 @@
               "id"      "@id"
               "rdf"     "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
               "schema"  "http://schema.org/"
-              "type"    "@type"}
+              "type"    "@type"
+              "graph"   "@graph"}
              default-context-1)))))

--- a/test/fluree/http_api/integration/history_query_test.clj
+++ b/test/fluree/http_api/integration/history_query_test.clj
@@ -23,8 +23,8 @@
     (let [ledger-name   "history-query-json-test"
           txn-req       {:body
                          (json/write-value-as-string
-                          {"ledger" ledger-name
-                           "txn"    [{"id"      "ex:query-test"
+                          {"@id"    ledger-name
+                           "@graph" [{"id"      "ex:query-test"
                                       "type"    "schema:Test"
                                       "ex:name" "query-test"}]})
                          :headers json-headers}
@@ -80,10 +80,10 @@
     (let [ledger-name   "history-query-edn-test"
           txn-req       {:body
                          (pr-str
-                          {:ledger ledger-name
-                           :txn    [{:id      :ex/query-test
-                                     :type    :schema/Test
-                                     :ex/name "query-test"}]})
+                          {:id    ledger-name
+                           :graph [{:id      :ex/query-test
+                                    :type    :schema/Test
+                                    :ex/name "query-test"}]})
                          :headers edn-headers}
           txn-res       (api-post :create txn-req)
           _             (assert (= 201 (:status txn-res)))

--- a/test/fluree/http_api/integration/test_system.clj
+++ b/test/fluree/http_api/integration/test_system.clj
@@ -36,6 +36,7 @@
                             {:context
                              {:id     "@id"
                               :type   "@type"
+                              :graph  "@graph"
                               :ex     "http://example.com/"
                               :schema "http://schema.org/"
                               :rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -60,11 +61,11 @@
 (defn create-rand-ledger
   [name-root]
   (let [ledger-name (str name-root "-" (random-uuid))
-        req         (pr-str {:id      ledger-name
-                             :context ["" {:foo "http://foobar.com/"}]
-                             :graph   [{:id       :foo/create-test
-                                        :type     :foo/test
-                                        :foo/name "create-endpoint-test"}]})
+        req         (pr-str {:id               ledger-name
+                             :f/defaultContext ["" {:foo "http://foobar.com/"}]
+                             :graph            [{:id       :foo/create-test
+                                                 :type     :foo/test
+                                                 :foo/name "create-endpoint-test"}]})
         headers     {"Content-Type" "application/edn"
                      "Accept"       "application/edn"}
         res         (update (api-post :create {:body req :headers headers})
@@ -74,6 +75,6 @@
       (throw (ex-info "Error creating random ledger" res)))))
 
 (def auth
-  {:id "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh"
-   :public "03b160698617e3b4cd621afd96c0591e33824cb9753ab2f1dace567884b4e242b0"
+  {:id      "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh"
+   :public  "03b160698617e3b4cd621afd96c0591e33824cb9753ab2f1dace567884b4e242b0"
    :private "509553eece84d5a410f1012e8e19e84e938f226aa3ad144e2d12f36df0f51c1e"})

--- a/test/fluree/http_api/integration/test_system.clj
+++ b/test/fluree/http_api/integration/test_system.clj
@@ -60,11 +60,11 @@
 (defn create-rand-ledger
   [name-root]
   (let [ledger-name (str name-root "-" (random-uuid))
-        req         (pr-str {:ledger         ledger-name
-                             :defaultContext ["" {:foo "http://foobar.com/"}]
-                             :txn            [{:id       :foo/create-test
-                                               :type     :foo/test
-                                               :foo/name "create-endpoint-test"}]})
+        req         (pr-str {:id      ledger-name
+                             :context ["" {:foo "http://foobar.com/"}]
+                             :graph   [{:id       :foo/create-test
+                                        :type     :foo/test
+                                        :foo/name "create-endpoint-test"}]})
         headers     {"Content-Type" "application/edn"
                      "Accept"       "application/edn"}
         res         (update (api-post :create {:body req :headers headers})


### PR DESCRIPTION
Instead of `ledger` & `txn` use `@id` & `@graph` like `/transact` does. Checks that the ledger named by `@id` doesn't yet exist, creates it if not, and then transacts the data in `@graph` into it.

I was working on syncing up the latest changes in here w/ server and noticed this inconsistency in both code bases. Not sure if we intentionally left it like this just to change things incrementally (which is good), but it seemed good either way to make this consistent.