### PR TITLE
Replace @id w/ f:ledger in transactions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.12.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "f86c53cdb6dc08eff0c3b6609f2760d98daa209b"}}
+                                         :git/sha "d9f98110b0fd232c045fa9f80f6410dfdbbad75f"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          metosin/malli                  {:mvn/version "0.12.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "7aefac5fc79029b13b6924486b621b13c6d428df"}}
+                                         :git/sha "f86c53cdb6dc08eff0c3b6609f2760d98daa209b"}}
 
  :aliases
  {:dev

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -78,8 +78,10 @@
 (defhandler transact
   [{:keys [fluree/conn content-type credential/did]
     {:keys [body]} :parameters}]
+  (log/trace "transact handler req body:" body)
   (let [opts (cond-> (opts->context-type {} content-type)
                did (assoc :did did))
+        _    (log/trace "transact handler opts:" opts)
         db   (-> conn
                  (fluree/transact! body opts)
                  deref!)]

--- a/test/fluree/http_api/integration/basic_query_test.clj
+++ b/test/fluree/http_api/integration/basic_query_test.clj
@@ -11,10 +11,10 @@
     (let [ledger-name (create-rand-ledger "query-endpoint-basic-entity-test")
           txn-req     {:body
                        (json/write-value-as-string
-                         {"@id"    ledger-name
-                          "@graph" [{"id"      "ex:query-test"
-                                     "type"    "schema:Test"
-                                     "ex:name" "query-test"}]})
+                         {"f:ledger" ledger-name
+                          "@graph"   [{"id"      "ex:query-test"
+                                       "type"    "schema:Test"
+                                       "ex:name" "query-test"}]})
                        :headers json-headers}
           txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
@@ -35,13 +35,13 @@
     (let [ledger-name (create-rand-ledger "query-endpoint-union-test")
           txn-req     {:body
                        (json/write-value-as-string
-                         {"@id" ledger-name
-                          "@graph"    [{"id"      "ex:query-test"
-                                        "type"    "schema:Test"
-                                        "ex:name" "query-test"}
-                                       {"id"       "ex:wes"
-                                        "type"     "schema:Person"
-                                        "ex:fname" "Wes"}]})
+                         {"f:ledger" ledger-name
+                          "@graph"   [{"id"      "ex:query-test"
+                                       "type"    "schema:Test"
+                                       "ex:name" "query-test"}
+                                      {"id"       "ex:wes"
+                                       "type"     "schema:Person"
+                                       "ex:fname" "Wes"}]})
                        :headers json-headers}
           txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
@@ -62,22 +62,22 @@
     (let [ledger-name (create-rand-ledger "query-endpoint-optional-test")
           txn-req     {:body
                        (json/write-value-as-string
-                         {"@id" ledger-name
-                          "@graph"    [{"id"          "ex:brian",
-                                        "type"        "ex:User",
-                                        "schema:name" "Brian"
-                                        "ex:friend"   [{"id" "ex:alice"}]}
-                                       {"id"           "ex:alice",
-                                        "type"         "ex:User",
-                                        "ex:favColor"  "Green"
-                                        "schema:email" "alice@flur.ee"
-                                        "schema:name"  "Alice"}
-                                       {"id"           "ex:cam",
-                                        "type"         "ex:User",
-                                        "schema:name"  "Cam"
-                                        "schema:email" "cam@flur.ee"
-                                        "ex:friend"    [{"id" "ex:brian"}
-                                                        {"id" "ex:alice"}]}]})
+                         {"f:ledger" ledger-name
+                          "@graph"   [{"id"          "ex:brian",
+                                       "type"        "ex:User",
+                                       "schema:name" "Brian"
+                                       "ex:friend"   [{"id" "ex:alice"}]}
+                                      {"id"           "ex:alice",
+                                       "type"         "ex:User",
+                                       "ex:favColor"  "Green"
+                                       "schema:email" "alice@flur.ee"
+                                       "schema:name"  "Alice"}
+                                      {"id"           "ex:cam",
+                                       "type"         "ex:User",
+                                       "schema:name"  "Cam"
+                                       "schema:email" "cam@flur.ee"
+                                       "ex:friend"    [{"id" "ex:brian"}
+                                                       {"id" "ex:alice"}]}]})
                        :headers json-headers}
           txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
@@ -102,10 +102,10 @@
     (let [ledger-name (create-rand-ledger "query-endpoint-selectOne-test")
           txn-req     {:body
                        (json/write-value-as-string
-                         {"@id" ledger-name
-                          "@graph"    [{"id"      "ex:query-test"
-                                        "type"    "schema:Test"
-                                        "ex:name" "query-test"}]})
+                         {"f:ledger" ledger-name
+                          "@graph"   [{"id"      "ex:query-test"
+                                       "type"    "schema:Test"
+                                       "ex:name" "query-test"}]})
                        :headers json-headers}
           txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
@@ -127,7 +127,7 @@
           txn-req     {:headers json-headers
                        :body
                        (json/write-value-as-string
-                         {"@id" ledger-name
+                         {"f:ledger" ledger-name
                           "f:defaultContext"
                           {"id"     "@id"
                            "type"   "@type"
@@ -197,9 +197,7 @@
   (testing "can query a basic entity w/ EDN"
     (let [ledger-name (create-rand-ledger "query-endpoint-basic-entity-test")
           txn-req     {:body
-                       (pr-str {:context {:id "@id"
-                                          :graph "@graph"}
-                                :id ledger-name
+                       (pr-str {:f/ledger ledger-name
                                 :graph    [{:id      :ex/query-test
                                             :type    :schema/Test
                                             :ex/name "query-test"}]})

--- a/test/fluree/http_api/integration/basic_transaction_test.clj
+++ b/test/fluree/http_api/integration/basic_transaction_test.clj
@@ -11,7 +11,7 @@
     (let [ledger-name (str "create-endpoint-" (random-uuid))
           address     (str "fluree:memory://" ledger-name "/main/head")
           req         (json/write-value-as-string
-                       {"@id"      ledger-name
+                       {"f:ledger" ledger-name
                         "@context" ["" {"foo" "http://foobar.com/"}]
                         "@graph"   [{"id"      "ex:create-test"
                                      "type"    "foo:test"
@@ -24,11 +24,11 @@
              (-> res :body json/read-value)))))
   (testing "responds with 409 error if ledger already exists"
     (let [ledger-name (str "create-endpoint-" (random-uuid))
-          req         (pr-str {:id      ledger-name
-                               :context ["" {:foo "http://foobar.com/"}]
-                               :graph   [{:id      :ex/create-test
-                                          :type    :foo/test
-                                          :ex/name "create-endpoint-test"}]})
+          req         (pr-str {:f/ledger ledger-name
+                               :context  ["" {:foo "http://foobar.com/"}]
+                               :graph    [{:id      :ex/create-test
+                                           :type    :foo/test
+                                           :ex/name "create-endpoint-test"}]})
           res-success (api-post :create {:body req :headers edn-headers})
           _           (assert (= 201 (:status res-success)))
           res-fail    (api-post :create {:body req :headers edn-headers})]
@@ -38,11 +38,11 @@
     (testing "can create a new ledger w/ EDN"
       (let [ledger-name (str "create-endpoint-" (random-uuid))
             address     (str "fluree:memory://" ledger-name "/main/head")
-            req         (pr-str {:id      ledger-name
-                                 :context ["" {:foo "http://foobar.com/"}]
-                                 :graph   [{:id      :ex/create-test
-                                            :type    :foo/test
-                                            :ex/name "create-endpoint-test"}]})
+            req         (pr-str {:f/ledger ledger-name
+                                 :context  ["" {:foo "http://foobar.com/"}]
+                                 :graph    [{:id      :ex/create-test
+                                             :type    :foo/test
+                                             :ex/name "create-endpoint-test"}]})
             res         (api-post :create {:body req :headers edn-headers})]
         (is (= 201 (:status res)))
         (is (= {:address address
@@ -51,11 +51,11 @@
                (-> res :body edn/read-string)))))
     (testing "responds with 409 error if ledger already exists"
       (let [ledger-name (str "create-endpoint-" (random-uuid))
-            req         (pr-str {:id      ledger-name
-                                 :context ["" {:foo "http://foobar.com/"}]
-                                 :graph   [{:id      :ex/create-test
-                                            :type    :foo/test
-                                            :ex/name "create-endpoint-test"}]})
+            req         (pr-str {:f/ledger ledger-name
+                                 :context  ["" {:foo "http://foobar.com/"}]
+                                 :graph    [{:id      :ex/create-test
+                                             :type    :foo/test
+                                             :ex/name "create-endpoint-test"}]})
             res-success (api-post :create {:body req :headers edn-headers})
             _           (assert (= 201 (:status res-success)))
             res-fail    (api-post :create {:body req :headers edn-headers})]
@@ -66,10 +66,10 @@
     (let [ledger-name (create-rand-ledger "transact-endpoint-json-test")
           address     (str "fluree:memory://" ledger-name "/main/head")
           req         (json/write-value-as-string
-                        {"@id"    ledger-name
-                         "@graph" {"id"      "ex:transaction-test"
-                                   "type"    "schema:Test"
-                                   "ex:name" "transact-endpoint-json-test"}})
+                        {"f:ledger" ledger-name
+                         "@graph"   {"id"      "ex:transaction-test"
+                                     "type"    "schema:Test"
+                                     "ex:name" "transact-endpoint-json-test"}})
           res         (api-post :transact {:body req :headers json-headers})]
       (is (= 200 (:status res)))
       (is (= {"address" address, "alias" ledger-name, "t" 2}
@@ -78,7 +78,7 @@
     (let [ledger-name (create-rand-ledger "transact-endpoint-json-test")
           address     (str "fluree:memory://" ledger-name "/main/head")
           req         (json/write-value-as-string
-                        {"@id"      ledger-name
+                        {"f:ledger" ledger-name
                          "@context" {"foo" "http://foo.com"}
                          "@graph"   {"id"      "ex:transaction-test"
                                      "type"    "schema:Test"
@@ -92,7 +92,7 @@
     (let [ledger-name (create-rand-ledger "transact-endpoint-json-test")
           address     (str "fluree:memory://" ledger-name "/main/head")
           req         (json/write-value-as-string
-                        {"@id"      ledger-name
+                        {"f:ledger" ledger-name
                          "@context" {"foo" "http://foo.com"}
                          "@graph"   [{"id"      "ex:transaction-test"
                                       "type"    "schema:Test"
@@ -112,12 +112,10 @@
       (let [ledger-name (create-rand-ledger "transact-endpoint-edn-test")
             address     (str "fluree:memory://" ledger-name "/main/head")
             req         (pr-str
-                          {:context {:id "@id"
-                                     :graph "@graph"}
-                           :id      ledger-name
-                           :graph   [{:id      :ex/transaction-test
-                                      :type    :schema/Test
-                                      :ex/name "transact-endpoint-edn-test"}]})
+                          {:f/ledger ledger-name
+                           :graph    [{:id      :ex/transaction-test
+                                       :type    :schema/Test
+                                       :ex/name "transact-endpoint-edn-test"}]})
             res         (api-post :transact {:body req :headers edn-headers})]
         (is (= 200 (:status res)))
         (is (= {:address address, :alias ledger-name, :t 2}

--- a/test/fluree/http_api/integration/default_context_test.clj
+++ b/test/fluree/http_api/integration/default_context_test.clj
@@ -40,22 +40,21 @@
                                    (dissoc "foo"))
           txn0-req             {:body
                                 (json/write-value-as-string
-                                  {"@context"       {"f" "https://ns.flur.ee/ledger#"}
-                                   "@id"            ledger-name
-                                   "@graph"         [{"id"      "ex:nobody"
-                                                      "ex:name" "Nobody"}]
-                                   "f:defaultContext" default-context1})
+                                 {"@context"         {"f" "https://ns.flur.ee/ledger#"}
+                                  "f:ledger"         ledger-name
+                                  "@graph"           [{"id"      "ex:nobody"
+                                                       "ex:name" "Nobody"}]
+                                  "f:defaultContext" default-context1})
                                 :headers json-headers}
           txn0-res             (api-post :transact txn0-req)
           _                    (assert (= 200 (:status txn0-res)) (str "result was " txn0-res))
           txn1-req             {:body
                                 (json/write-value-as-string
-                                  {"@context" {"f" "https://ns.flur.ee/ledger#"}
-
-                                   "@id"              ledger-name
-                                   "@graph"           [{"id"      "ex:somebody"
-                                                        "ex:name" "Somebody"}]
-                                   "f:defaultContext" default-context2})
+                                 {"@context"         {"f" "https://ns.flur.ee/ledger#"}
+                                  "f:ledger"         ledger-name
+                                  "@graph"           [{"id"      "ex:somebody"
+                                                       "ex:name" "Somebody"}]
+                                  "f:defaultContext" default-context2})
                                 :headers json-headers}
           txn1-res             (api-post :transact txn1-req)
           _                    (assert (= 200 (:status txn1-res)))
@@ -111,14 +110,14 @@
           default-context-res  (api-get :defaultContext default-context-req)
           default-context-0    (-> default-context-res :body json/read-value)
           update-req           {:body    (json/write-value-as-string
-                                           {"@context" {"f" "https://ns.flur.ee/ledger#"}
-                                            "@id"      ledger-name
-                                            "@graph"   [{:ex/name "Foo"}]
-                                            "f:defaultContext"
-                                            (-> default-context-0
-                                                (assoc "foo-new"
-                                                       (get default-context-0 "foo"))
-                                                (dissoc "foo"))})
+                                          {"@context" {"f" "https://ns.flur.ee/ledger#"}
+                                           "f:ledger" ledger-name
+                                           "@graph"   [{:ex/name "Foo"}]
+                                           "f:defaultContext"
+                                           (-> default-context-0
+                                               (assoc "foo-new"
+                                                      (get default-context-0 "foo"))
+                                               (dissoc "foo"))})
                                 :headers json-headers}
           update-res           (api-post :transact update-req)
           _                    (assert (= 200 (:status update-res))

--- a/test/fluree/http_api/integration/history_query_test.clj
+++ b/test/fluree/http_api/integration/history_query_test.clj
@@ -23,18 +23,18 @@
     (let [ledger-name   "history-query-json-test"
           txn-req       {:body
                          (json/write-value-as-string
-                          {"@id"    ledger-name
-                           "@graph" [{"id"      "ex:query-test"
-                                      "type"    "schema:Test"
-                                      "ex:name" "query-test"}]})
+                          {"f:ledger" ledger-name
+                           "@graph"   [{"id"      "ex:query-test"
+                                        "type"    "schema:Test"
+                                        "ex:name" "query-test"}]})
                          :headers json-headers}
           txn-res       (api-post :create txn-req)
           _             (assert (= 201 (:status txn-res)))
           txn2-req      {:body
                          (json/write-value-as-string
-                           {"@id" ledger-name
-                            "@graph"    [{"id"           "ex:query-test"
-                                          "ex:test-type" "integration"}]})
+                           {"f:ledger" ledger-name
+                            "@graph"   [{"id"           "ex:query-test"
+                                         "ex:test-type" "integration"}]})
                          :headers json-headers}
           txn2-res      (api-post :transact txn2-req)
           _             (assert (= 200 (:status txn2-res)))
@@ -80,18 +80,18 @@
     (let [ledger-name   "history-query-edn-test"
           txn-req       {:body
                          (pr-str
-                          {:id    ledger-name
-                           :graph [{:id      :ex/query-test
-                                    :type    :schema/Test
-                                    :ex/name "query-test"}]})
+                          {:f/ledger ledger-name
+                           :graph    [{:id      :ex/query-test
+                                       :type    :schema/Test
+                                       :ex/name "query-test"}]})
                          :headers edn-headers}
           txn-res       (api-post :create txn-req)
           _             (assert (= 201 (:status txn-res)))
           txn2-req      {:body
                          (pr-str
-                           {:context {:id "@id"
-                                      :graph "@graph"}
-                            :id ledger-name
+                           {:context  {:id "@id"
+                                       :graph "@graph"}
+                            :f/ledger ledger-name
                             :graph    [{:id           :ex/query-test
                                         :ex/test-type "integration"}]})
                          :headers edn-headers}

--- a/test/fluree/http_api/integration/policy_test.clj
+++ b/test/fluree/http_api/integration/policy_test.clj
@@ -12,30 +12,34 @@
           alice-did    "did:fluree:Tf6i5oh2ssYNRpxxUM2zea1Yo7x4uRqyTeU"
           txn-req      {:body
                         (json/write-value-as-string
-                          {"@id" ledger-name
-                           "@graph"    [{"id"        "ex:alice"
-                                         "type"      "ex:User"
-                                         "ex:secret" "alice's secret"}
-                                        {"id"        "ex:bob"
-                                         "type"      "ex:User"
-                                         "ex:secret" "bob's secret"}
-                                        {"id"            "ex:UserPolicy"
-                                         "type"          ["f:Policy"]
-                                         "f:targetClass" {"id" "ex:User"}
-                                         "f:allow"
-                                         [{"id"           "ex:globalViewAllow"
-                                           "f:targetRole" {"id" "ex:userRole"}
-                                           "f:action"     [{"id" "f:view"}]}]
-                                         "f:property"
-                                         [{"f:path" {"id" "ex:secret"}
-                                           "f:allow"
-                                           [{"id"           "ex:secretsRule"
-                                             "f:targetRole" {"id" "ex:userRole"}
-                                             "f:action"     [{"id" "f:view"} {"id" "f:modify"}]
-                                             "f:equals"     {"@list" [{"id" "f:$identity"} {"id" "ex:User"}]}}]}]}
-                                        {"id"      alice-did
-                                         "ex:User" {"id" "ex:alice"}
-                                         "f:role"  {"id" "ex:userRole"}}]})
+                          {"f:ledger" ledger-name
+                           "@graph"
+                           [{"id"        "ex:alice"
+                             "type"      "ex:User"
+                             "ex:secret" "alice's secret"}
+                            {"id"        "ex:bob"
+                             "type"      "ex:User"
+                             "ex:secret" "bob's secret"}
+                            {"id"            "ex:UserPolicy"
+                             "type"          ["f:Policy"]
+                             "f:targetClass" {"id" "ex:User"}
+                             "f:allow"
+                             [{"id"           "ex:globalViewAllow"
+                               "f:targetRole" {"id" "ex:userRole"}
+                               "f:action"     [{"id" "f:view"}]}]
+                             "f:property"
+                             [{"f:path" {"id" "ex:secret"}
+                               "f:allow"
+                               [{"id"           "ex:secretsRule"
+                                 "f:targetRole" {"id" "ex:userRole"}
+                                 "f:action"     [{"id" "f:view"}
+                                                 {"id" "f:modify"}]
+                                 "f:equals"     {"@list"
+                                                 [{"id" "f:$identity"}
+                                                  {"id" "ex:User"}]}}]}]}
+                            {"id"      alice-did
+                             "ex:User" {"id" "ex:alice"}
+                             "f:role"  {"id" "ex:userRole"}}]})
                         :headers json-headers}
           txn-res      (api-post :transact txn-req)
           _            (assert (= 200 (:status txn-res)) (str "response was" txn-res))
@@ -60,10 +64,10 @@
           "query policy opts should prevent seeing bob's secret")
       (let [txn-req   {:body
                        (json/write-value-as-string
-                         {"@context" {"f" "https://ns.flur.ee/ledger#" }
-                          "@id" ledger-name
-                          "@graph" [{"id"        "ex:alice"
-                                     "ex:secret" "alice's NEW secret"}]
+                         {"@context" {"f" "https://ns.flur.ee/ledger#"}
+                          "f:ledger" ledger-name
+                          "@graph"   [{"id"        "ex:alice"
+                                       "ex:secret" "alice's NEW secret"}]
                           "f:opts"   {"role" "ex:userRole"
                                       "did"  alice-did}})
                        :headers json-headers}
@@ -85,10 +89,10 @@
             "alice's secret should be modified")
         (let [txn-req {:body
                        (json/write-value-as-string
-                         {"@context" {"f" "https://ns.flur.ee/ledger#" }
-                          "@id" ledger-name
-                          "@graph"    [{"id"        "ex:bob"
-                                        "ex:secret" "bob's new secret"}]
+                         {"@context" {"f" "https://ns.flur.ee/ledger#"}
+                          "f:ledger" ledger-name
+                          "@graph"   [{"id"        "ex:bob"
+                                       "ex:secret" "bob's new secret"}]
                           "f:opts"   {"role" "ex:userRole"
                                       "did"  alice-did}})
                        :headers json-headers}
@@ -118,32 +122,34 @@
           alice-did    "did:fluree:Tf6i5oh2ssYNRpxxUM2zea1Yo7x4uRqyTeU"
           txn-req      {:body
                         (pr-str
-                          {:context {:id "@id"
-                                     :graph "@graph"}
-                           :id ledger-name
-                           :graph    [{:id        :ex/alice,
-                                       :type      :ex/User,
-                                       :ex/secret "alice's secret"}
-                                      {:id        :ex/bob,
-                                       :type      :ex/User,
-                                       :ex/secret "bob's secret"}
-                                      {:id            :ex/UserPolicy,
-                                       :type          [:f/Policy],
-                                       :f/targetClass :ex/User
-                                       :f/allow       [{:id           :ex/globalViewAllow
-                                                        :f/targetRole :ex/userRole
-                                                        :f/action     [:f/view]}]
-                                       :f/property    [{:f/path  :ex/secret
-                                                        :f/allow [{:id           :ex/secretsRule
-                                                                   :f/targetRole :ex/userRole
-                                                                   :f/action     [:f/view :f/modify]
-                                                                   :f/equals     {:list [:f/$identity :ex/User]}}]}]}
-                                      {:id      alice-did
-                                       :ex/User :ex/alice
-                                       :f/role  :ex/userRole}]})
+                          {:f/ledger ledger-name
+                           :graph
+                           [{:id        :ex/alice,
+                             :type      :ex/User,
+                             :ex/secret "alice's secret"}
+                            {:id        :ex/bob,
+                             :type      :ex/User,
+                             :ex/secret "bob's secret"}
+                            {:id            :ex/UserPolicy,
+                             :type          [:f/Policy],
+                             :f/targetClass :ex/User
+                             :f/allow       [{:id           :ex/globalViewAllow
+                                              :f/targetRole :ex/userRole
+                                              :f/action     [:f/view]}]
+                             :f/property    [{:f/path  :ex/secret
+                                              :f/allow
+                                              [{:id           :ex/secretsRule
+                                                :f/targetRole :ex/userRole
+                                                :f/action     [:f/view :f/modify]
+                                                :f/equals
+                                                {:list [:f/$identity :ex/User]}}]}]}
+                            {:id      alice-did
+                             :ex/User :ex/alice
+                             :f/role  :ex/userRole}]})
                         :headers edn-headers}
           txn-res      (api-post :transact txn-req)
-          _            (assert (= 200 (:status txn-res)))
+          _            (assert (= 200 (:status txn-res))
+                               (str "Transaction response was: " (pr-str txn-res)))
           secret-query {:from    ledger-name
                         :select '{?s [:*]}
                         :where  '[[?s :rdf/type :ex/User]]}
@@ -166,10 +172,10 @@
           "query policy opts should prevent seeing bob's secret")
       (let [txn-req   {:body
                        (pr-str
-                         {:context {:id    "@id"
-                                    :graph "@graph"
-                                    :f     "https://ns.flur.ee/ledger#"}
-                          :id ledger-name
+                         {:context  {:id    "@id"
+                                     :graph "@graph"
+                                     :f     "https://ns.flur.ee/ledger#"}
+                          :f/ledger ledger-name
                           :graph    [{:id        :ex/alice
                                       :ex/secret "alice's NEW secret"}]
                           :f/opts   {:role :ex/userRole
@@ -193,14 +199,14 @@
             "alice's secret should be modified")
         (let [txn-req {:body
                        (pr-str
-                         {:context {:id    "@id"
-                                    :graph "@graph"
-                                    :f     "https://ns.flur.ee/ledger#"}
-                          :id      ledger-name
-                          :graph   [{:id        :ex/bob
-                                     :ex/secret "bob's NEW secret"}]
-                          :f/opts    {:role :ex/userRole
-                                      :did  alice-did}})
+                         {:context  {:id    "@id"
+                                     :graph "@graph"
+                                     :f     "https://ns.flur.ee/ledger#"}
+                          :f/ledger ledger-name
+                          :graph    [{:id        :ex/bob
+                                      :ex/secret "bob's NEW secret"}]
+                          :f/opts   {:role :ex/userRole
+                                     :did  alice-did}})
                        :headers edn-headers}
               txn-res (api-post :transact txn-req)]
           (is (not= 200 (:status txn-res))

--- a/test/fluree/http_api/integration/sparql_test.clj
+++ b/test/fluree/http_api/integration/sparql_test.clj
@@ -10,10 +10,10 @@
     (let [ledger-name (create-rand-ledger "query-sparql-test")
           txn-req     {:body
                        (json/write-value-as-string
-                        {"@id"    ledger-name
-                         "@graph" [{"id"      "ex:query-sparql-test"
-                                    "type"    "schema:Test"
-                                    "ex:name" "query-sparql-test"}]})
+                        {"f:ledger" ledger-name
+                         "@graph"   [{"id"      "ex:query-sparql-test"
+                                      "type"    "schema:Test"
+                                      "ex:name" "query-sparql-test"}]})
                        :headers json-headers}
           txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))

--- a/test/fluree/http_api/integration/test_system.clj
+++ b/test/fluree/http_api/integration/test_system.clj
@@ -61,7 +61,7 @@
 (defn create-rand-ledger
   [name-root]
   (let [ledger-name (str name-root "-" (random-uuid))
-        req         (pr-str {:id               ledger-name
+        req         (pr-str {:f/ledger         ledger-name
                              :f/defaultContext ["" {:foo "http://foobar.com/"}]
                              :graph            [{:id       :foo/create-test
                                                  :type     :foo/test


### PR DESCRIPTION
Along with https://github.com/fluree/db/pull/578 changes `@id` to `https://ns.flur.ee/ledger#ledger` (usually abbreviated as `f:ledger` via default context) in transactions as the ledger specifier.

This is more semantically correct and lets us control the JSON-LD expectations around the allowed / expected values. `@id` is supposed to always be a valid IRI, but our ledger aliases aren't necessarily. This led to at least one security hole w/ credential-wrapped transactions.

Part of https://github.com/fluree/core/issues/32