### PR TITLE
Update deps & GitHub Actions to latest compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     name: docker build cache
     runs-on: [linux, large, docker]
     steps:
-      - uses: docker/setup-buildx-action@v2.5.0
+      - uses: docker/setup-buildx-action@v3
         with:
           install: true
-      - uses: docker/build-push-action@v4
+      - uses: docker/build-push-action@v5
         id: build
         with:
           cache-from: type=gha
@@ -26,10 +26,10 @@ jobs:
     needs: docker-build-cache
     runs-on: [linux, large, docker]
     steps:
-      - uses: docker/setup-buildx-action@v2.5.0
+      - uses: docker/setup-buildx-action@v3
         with:
           install: true
-      - uses: docker/build-push-action@v4
+      - uses: docker/build-push-action@v5
         with:
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,7 @@
          metosin/malli                  {:mvn/version "0.13.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "ba063873a22de7787c5f6d264b3fd1d7ea1d69f3"}}
+                                         :git/sha "6c9fbd237dacc0dc9dec49feda9b28eb48ac31eb"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,7 @@
          metosin/malli                  {:mvn/version "0.13.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "d9f98110b0fd232c045fa9f80f6410dfdbbad75f"}}
+                                         :git/sha "ba063873a22de7787c5f6d264b3fd1d7ea1d69f3"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -3,12 +3,14 @@
          org.clojure/core.async         {:mvn/version "1.6.681"}
          club.donutpower/system         {:mvn/version "0.0.165"}
          aero/aero                      {:mvn/version "1.1.6"}
-         info.sunng/ring-jetty9-adapter {:mvn/version "0.22.1"}
+         ;; ring-jetty9-adapter 0.30.x uses Jetty 12 & requires JDK 17+
+         ;; so we have to stay on 0.22.x b/c our minimum JDK version is 11
+         info.sunng/ring-jetty9-adapter ^{:antq/exclude "0.30.x"} {:mvn/version "0.22.2"}
          ch.qos.logback/logback-classic {:mvn/version "1.4.11"}
          org.slf4j/slf4j-api            {:mvn/version "2.0.9"}
          metosin/reitit                 {:mvn/version "0.6.0"}
          metosin/muuntaja               {:mvn/version "0.6.8"}
-         metosin/malli                  {:mvn/version "0.12.0"}
+         metosin/malli                  {:mvn/version "0.13.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
                                          :git/sha "d9f98110b0fd232c045fa9f80f6410dfdbbad75f"}}
@@ -27,7 +29,7 @@
 
   :test
   {:extra-paths ["test"]
-   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.86.1355"}
+   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.87.1366"}
                  clj-http/clj-http   {:mvn/version "3.12.3"}}
    :exec-fn     kaocha.runner/exec-fn
    :exec-args   {}}


### PR DESCRIPTION
Similar to https://github.com/fluree/db/pull/581 this updates deps and GitHub Actions to their latest compatible versions.

There is another–but slightly different–[antq](https://github.com/liquidz/antq) exclusion to keep us on ring-jetty9-adapter 0.22.x. 0.30.x requires JDK 17, but our minimum version is JDK 11.