### PR TITLE
Fix: thread safety

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ eastwood:
 .PHONY: ci
 ci: test eastwood
 
+.PHONY: test-verbose
+test-verbose:
+	clojure -X:test-verbose
+
 .PHONY: clean
 clean:
 	rm -rf target

--- a/deps.edn
+++ b/deps.edn
@@ -38,6 +38,13 @@
   {:extra-deps {jonase/eastwood {:mvn/version "1.4.0"}}
    :main-opts  ["-m" "eastwood.lint" {}]}
 
+  :test-verbose
+  {:extra-paths ["test"]
+   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.86.1355"}
+                 clj-http/clj-http   {:mvn/version "3.12.3"}}
+   :exec-fn     kaocha.runner/exec-fn
+   :exec-args   {:kaocha.plugin.capture-output/capture-output? false}}
+
   :run-dev
   {:exec-fn   fluree.http-api.system/run-server
    :exec-args {:profile :dev}}}}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -18,4 +18,5 @@
                                          #profile {:dev
                                                    {:id   "@id"
                                                     :type "@type"
-                                                    :ex   "http://example.com/"}}]}}}
+                                                    :ex   "http://example.com/"}}]}}
+ :fluree/txn-queue  {:length 10}}

--- a/src/fluree/http_api/components/txn_queue.clj
+++ b/src/fluree/http_api/components/txn_queue.clj
@@ -1,0 +1,62 @@
+(ns fluree.http-api.components.txn-queue
+  (:require [clojure.core.async :as async :refer [<!! >!! alt!! put!]]
+            [donut.system :as ds]
+            [fluree.db.json-ld.api :as fluree]
+            [fluree.db.util.log :as log]))
+
+(set! *warn-on-reflection* true)
+
+;; In theory you could parallelize transaction processing for different ledgers
+;; but this component is typically used for dev environments where you don't
+;; want to deal with raft / a whole cluster of servers. And typically you don't
+;; care about performance / parallelization too much there, and often aren't
+;; working with more than one ledger at a time anyway. So this implements a
+;; simple global queue to ensure that only one transaction is processed at a
+;; time for correctness.
+
+(defn process-job
+  [conn
+   {:keys [::result-chan] {:keys [::txn ::opts ::txn-type]} ::req}]
+  (log/trace "Processing" txn-type "job:" txn)
+  (let [result (try
+                 (if (= :create txn-type)
+                   @(fluree/create-with-txn conn txn opts)
+                   @(fluree/transact! conn txn opts))
+                 (catch Exception e e))]
+    (>!! result-chan result)))
+
+(defn start!
+  [conn {:keys [queue-len] :as cfg}]
+  (log/info "Starting transaction processor with config:" cfg)
+  (let [queue (async/chan queue-len)]
+    (async/thread
+     (loop []
+       (let [job (<!! queue)]
+         (when-not (nil? job)
+           (process-job conn job)
+           (recur)))))
+    queue))
+
+(defn stop!
+  [queue]
+  (log/info "Stopping transaction processor")
+  (async/close! queue))
+
+(def processor
+  #::ds{:start  (fn [{{:keys [:fluree/txn-queue-len :fluree/connection]}
+                      ::ds/config}]
+                  (start! connection {:queue-len txn-queue-len}))
+        :stop   (fn [{:keys [::ds/instance]}]
+                  (stop! instance))
+        :config {:fluree/txn-queue-len (ds/ref [:env :fluree/txn-queue :length])
+                 :fluree/connection    (ds/ref [:fluree :conn])}})
+
+(defn submit
+  "Submits a transaction to the queue for processing and returns immediately
+  with a channel that will contain the result (or an exception) once it's
+  processed."
+  [queue txn]
+  (let [result-ch (async/chan 1)]
+    (put! queue {::req txn ::result-chan result-ch}
+          (fn [_] (log/trace "Transaction queued:" txn)))
+    result-ch))

--- a/test/fluree/http_api/integration/test_system.clj
+++ b/test/fluree/http_api/integration/test_system.clj
@@ -40,7 +40,8 @@
                               :ex     "http://example.com/"
                               :schema "http://schema.org/"
                               :rdf    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                              :f      "https://ns.flur.ee/ledger#"}}}}}))
+                              :f      "https://ns.flur.ee/ledger#"}}}
+                           :fluree/txn-queue {:length 1}}}))
 
 (defn run-test-server
   [run-tests]


### PR DESCRIPTION
Closes #66 

I had been noodling on this here and there in between other things and got it to a place that seemed workable. It's pretty simple but so is the problem it needs to solve. It is one global queue, but that seems fine for an operational mode intended for local dev where we just need to ensure that concurrent transactions don't cause incorrect behavior.

Any use case that needs more than this should use a cluster of `fluree/server` instances instead.