### PR TITLE
Allow overriding default context w/ EDN or JSON file

### DIFF
--- a/.cljstyle
+++ b/.cljstyle
@@ -1,0 +1,7 @@
+{:rules
+ {:indentation
+  {:list-indent 1}
+  :whitespace
+  {:remove-surrounding? true
+   :remove-trailing?    true
+   :insert-missing?     true}}}

--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,7 @@
          metosin/malli                  {:mvn/version "0.13.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "6c9fbd237dacc0dc9dec49feda9b28eb48ac31eb"}}
+                                         :git/sha "a9cbf41c355ac7415239fa37e6eb3790faad15b0"}}
 
  :aliases
  {:dev

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -15,6 +15,7 @@
                                                   :docker "data"}]
                      :defaults     {:context
                                     #or [#env FLUREE_DEFAULT_CONTEXT
+                                         #include-json-or-edn #env FLUREE_DEFAULT_CONTEXT_FILE
                                          #profile {:dev
                                                    {:id   "@id"
                                                     :type "@type"

--- a/test/fluree/http_api/integration/basic_transaction_test.clj
+++ b/test/fluree/http_api/integration/basic_transaction_test.clj
@@ -16,22 +16,25 @@
                         "@graph"   [{"id"      "ex:create-test"
                                      "type"    "foo:test"
                                      "ex:name" "create-endpoint-test"}]})
+          _           (println "REQUEST:" (pr-str req))
           res         (api-post :create {:body req :headers json-headers})]
-      (is (= 201 (:status res)))
+      (is (= 201 (:status res))
+          (str "response was:" (pr-str res)))
       (is (= {"address" address
               "alias"   ledger-name
               "t"       1}
              (-> res :body json/read-value)))))
   (testing "responds with 409 error if ledger already exists"
     (let [ledger-name (str "create-endpoint-" (random-uuid))
-          req         (pr-str {:f/ledger ledger-name
-                               :context  ["" {:foo "http://foobar.com/"}]
-                               :graph    [{:id      :ex/create-test
-                                           :type    :foo/test
-                                           :ex/name "create-endpoint-test"}]})
-          res-success (api-post :create {:body req :headers edn-headers})
+          req         (json/write-value-as-string
+                       {"f:ledger" ledger-name
+                        "@context" {"f" "https://ns.flur.ee/ledger#"} #_["" {"foo" "http://foobar.com/"}]
+                        "@graph"   [{"id"      "ex:create-test"
+                                     "type"    "foo:test"
+                                     "ex:name" "create-endpoint-test"}]})
+          res-success (api-post :create {:body req :headers json-headers})
           _           (assert (= 201 (:status res-success)))
-          res-fail    (api-post :create {:body req :headers edn-headers})]
+          res-fail    (api-post :create {:body req :headers json-headers})]
       (is (= 409 (:status res-fail))))))
 
 (deftest ^:integration ^:edn create-endpoint-edn-test
@@ -79,7 +82,7 @@
           address     (str "fluree:memory://" ledger-name "/main/head")
           req         (json/write-value-as-string
                         {"f:ledger" ledger-name
-                         "@context" {"foo" "http://foo.com"}
+                         "@context" ["" {"foo" "http://foo.com"}]
                          "@graph"   {"id"      "ex:transaction-test"
                                      "type"    "schema:Test"
                                      "foo:bar" "Baz"
@@ -93,7 +96,7 @@
           address     (str "fluree:memory://" ledger-name "/main/head")
           req         (json/write-value-as-string
                         {"f:ledger" ledger-name
-                         "@context" {"foo" "http://foo.com"}
+                         "@context" ["" {"foo" "http://foo.com"}]
                          "@graph"   [{"id"      "ex:transaction-test"
                                       "type"    "schema:Test"
                                       "foo:bar" "Baz"

--- a/test/fluree/http_api/integration/history_query_test.clj
+++ b/test/fluree/http_api/integration/history_query_test.clj
@@ -89,8 +89,7 @@
           _             (assert (= 201 (:status txn-res)))
           txn2-req      {:body
                          (pr-str
-                           {:context  {:id "@id"
-                                       :graph "@graph"}
+                           {:context  ["" {:id "@id", :graph "@graph"}]
                             :f/ledger ledger-name
                             :graph    [{:id           :ex/query-test
                                         :ex/test-type "integration"}]})


### PR DESCRIPTION
Closes #76

This is less awkward than stuffing default contexts into an env var.