### PR TITLE
Use error formatting fn in query error coercion

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,7 +10,8 @@
          org.slf4j/slf4j-api            {:mvn/version "2.0.9"}
          metosin/reitit                 {:mvn/version "0.6.0"}
          metosin/muuntaja               {:mvn/version "0.6.8"}
-         metosin/malli                  {:mvn/version "0.13.0"}
+         metosin/malli                  {:git/url "https://github.com/metosin/malli.git"
+                                         :git/sha "5211aca498ff7b022c36de4ca713990f5e731a9c" }
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
                                          :git/sha "51de2707a76fd5237ea5c6ac04ca46861cbaa73d"}}

--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,7 @@
          metosin/malli                  {:mvn/version "0.13.0"}
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "a9cbf41c355ac7415239fa37e6eb3790faad15b0"}}
+                                         :git/sha "51de2707a76fd5237ea5c6ac04ca46861cbaa73d"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,7 @@
                                          :git/sha "5211aca498ff7b022c36de4ca713990f5e731a9c" }
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "51de2707a76fd5237ea5c6ac04ca46861cbaa73d"}}
+                                         :git/sha "b3392d5fa9e1e0fff3da435f29f20b168bbfcaf7"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,7 @@
                                          :git/sha "5211aca498ff7b022c36de4ca713990f5e731a9c" }
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "b3392d5fa9e1e0fff3da435f29f20b168bbfcaf7"}}
+                                         :git/sha "310e71e0175302660f8312f1410173e2b63c66a3"}}
 
  :aliases
  {:dev

--- a/src/fluree/http_api/components/http.clj
+++ b/src/fluree/http_api/components/http.clj
@@ -74,7 +74,7 @@
 
 (def FqlQuery (m/schema [:and
                          [:map-of :keyword :any]
-                         (fql/query-schema [[:from LedgerAlias]])]
+                         (fql/query-schema [])]
                         {:registry fql/registry}))
 
 (def SparqlQuery (m/schema :string))

--- a/src/fluree/http_api/handlers/ledger.clj
+++ b/src/fluree/http_api/handlers/ledger.clj
@@ -106,7 +106,7 @@
                    did (assoc :did did)))
         query* (if opts (assoc query :opts opts) query)]
     {:status 200
-     :body   (deref! (fluree/from-query conn query* {:format format}))}))
+     :body   (deref! (fluree/query-connection conn query* {:format format}))}))
 
 (defhandler history
   [{:keys [fluree/conn content-type credential/did] {{ledger :from :as query} :body} :parameters}]


### PR DESCRIPTION
Related to [#312](https://github.com/fluree/db/issues/312)

Uses error-formatting fn introduced in https://github.com/fluree/db/pull/598 to format validation errors for query endpoints